### PR TITLE
[feat] : 포인트 사용, 적립 구현

### DIFF
--- a/src/main/java/shop/sajotuna/common/exception/ApiException.java
+++ b/src/main/java/shop/sajotuna/common/exception/ApiException.java
@@ -1,0 +1,15 @@
+package shop.sajotuna.common.exception;
+
+import lombok.Getter;
+
+@Getter
+public class ApiException extends RuntimeException {
+    private final int status;
+    private final String message;
+
+    public ApiException(int status, String message) {
+        super(message);
+        this.status = status;
+        this.message = message;
+    }
+}

--- a/src/main/java/shop/sajotuna/common/exception/NegativePointException.java
+++ b/src/main/java/shop/sajotuna/common/exception/NegativePointException.java
@@ -1,0 +1,11 @@
+package shop.sajotuna.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class NegativePointException extends ApiException {
+    private static final String MESSAGE = "포인트는 음수로 설정할 수 없습니다.";
+
+    public NegativePointException() {
+        super(HttpStatus.BAD_REQUEST.value(), MESSAGE);
+    }
+}

--- a/src/main/java/shop/sajotuna/common/exception/UserPointNotFoundException.java
+++ b/src/main/java/shop/sajotuna/common/exception/UserPointNotFoundException.java
@@ -1,0 +1,12 @@
+package shop.sajotuna.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class UserPointNotFoundException extends ApiException {
+
+    private static final String MESSAGE = "User point not found.";
+
+    public UserPointNotFoundException() {
+        super(HttpStatus.NOT_FOUND.value(), MESSAGE);
+    }
+}

--- a/src/main/java/shop/sajotuna/order/point/controller/response/PointHistoryResponse.java
+++ b/src/main/java/shop/sajotuna/order/point/controller/response/PointHistoryResponse.java
@@ -1,0 +1,32 @@
+package shop.sajotuna.order.point.controller.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import shop.sajotuna.order.point.domain.PointHistory;
+import shop.sajotuna.order.point.domain.PointType;
+
+import java.time.LocalDateTime;
+
+@AllArgsConstructor
+@Getter
+public class PointHistoryResponse {
+    private Long id;
+
+    private Long userId;
+
+    private int amount;
+
+    private PointType type;
+
+    private LocalDateTime createdAt;
+
+    public static PointHistoryResponse from(PointHistory pointHistory) {
+        return new PointHistoryResponse(
+                pointHistory.getId(),
+                pointHistory.getUserId(),
+                pointHistory.getAmount(),
+                pointHistory.getType(),
+                pointHistory.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/shop/sajotuna/order/point/domain/InsufficientPointException.java
+++ b/src/main/java/shop/sajotuna/order/point/domain/InsufficientPointException.java
@@ -1,0 +1,14 @@
+package shop.sajotuna.order.point.domain;
+
+import org.springframework.http.HttpStatus;
+import shop.sajotuna.common.exception.ApiException;
+
+public class InsufficientPointException extends ApiException {
+
+    private static final String MESSAGE = "포인트가 부족합니다 잔여 포인트 : %d, 필요 포인트 : %d";
+
+    public InsufficientPointException(long remainPoint, long requiredPoint) {
+        super(HttpStatus.BAD_REQUEST.value(), String.format(MESSAGE, remainPoint, requiredPoint));
+
+    }
+}

--- a/src/main/java/shop/sajotuna/order/point/domain/PointHistory.java
+++ b/src/main/java/shop/sajotuna/order/point/domain/PointHistory.java
@@ -1,16 +1,18 @@
 package shop.sajotuna.order.point.domain;
 
 import jakarta.persistence.*;
-import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.PositiveOrZero;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
 @Getter
 @Entity
-public class Point {
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PointHistory {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -21,7 +23,7 @@ public class Point {
 
     @NotNull
     @PositiveOrZero
-    private Long amount;
+    private int amount;
 
     @Enumerated(value = EnumType.STRING)
     @NotNull
@@ -30,7 +32,10 @@ public class Point {
     @NotNull
     private LocalDateTime createdAt;
 
-    @NotNull
-    @PositiveOrZero
-    private Long remainPoint;
+    public PointHistory(Long userId, int amount, PointType type) {
+        this.userId = userId;
+        this.amount = amount;
+        this.type = type;
+        this.createdAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/shop/sajotuna/order/point/domain/PointPolicy.java
+++ b/src/main/java/shop/sajotuna/order/point/domain/PointPolicy.java
@@ -1,0 +1,25 @@
+package shop.sajotuna.order.point.domain;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+
+@Entity
+@Getter
+public class PointPolicy {
+
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @NotNull
+    private PointPolicyType type;
+
+    private Integer fixedPoint;
+
+    @Column(precision=4, scale=3)
+    private BigDecimal rate;
+}

--- a/src/main/java/shop/sajotuna/order/point/domain/PointPolicy.java
+++ b/src/main/java/shop/sajotuna/order/point/domain/PointPolicy.java
@@ -11,7 +11,7 @@ import java.math.BigDecimal;
 public class PointPolicy {
 
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/shop/sajotuna/order/point/domain/PointPolicyType.java
+++ b/src/main/java/shop/sajotuna/order/point/domain/PointPolicyType.java
@@ -1,0 +1,7 @@
+package shop.sajotuna.order.point.domain;
+
+public enum PointPolicyType {
+    PURCHASE,
+    REVIEW,
+    REGISTER
+}

--- a/src/main/java/shop/sajotuna/order/point/domain/UserPoint.java
+++ b/src/main/java/shop/sajotuna/order/point/domain/UserPoint.java
@@ -1,0 +1,46 @@
+package shop.sajotuna.order.point.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Version;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+import lombok.Getter;
+import shop.sajotuna.common.exception.NegativePointException;
+
+@Entity
+@Getter
+public class UserPoint {
+
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    @NotNull
+    private Long userId;
+
+    @NotNull
+    @PositiveOrZero
+    private Long remainPoint;
+
+    @Version
+    private Long version;
+
+    public void earnPoint(long amount) {
+        if (amount < 0) {
+            throw new NegativePointException();
+        }
+        this.remainPoint += amount;
+    }
+
+    public void redeemPoint(int pointAmount) {
+        if (remainPoint < pointAmount) {
+            throw new InsufficientPointException(remainPoint, pointAmount - remainPoint);
+        }
+        if (pointAmount < 0) {
+            throw new NegativePointException();
+        }
+        this.remainPoint -= pointAmount;
+    }
+}

--- a/src/main/java/shop/sajotuna/order/point/domain/UserPoint.java
+++ b/src/main/java/shop/sajotuna/order/point/domain/UserPoint.java
@@ -1,9 +1,6 @@
 package shop.sajotuna.order.point.domain;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Version;
+import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.PositiveOrZero;
 import lombok.Getter;
@@ -14,7 +11,7 @@ import shop.sajotuna.common.exception.NegativePointException;
 public class UserPoint {
 
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @NotNull

--- a/src/main/java/shop/sajotuna/order/point/repository/PointHistoryRepository.java
+++ b/src/main/java/shop/sajotuna/order/point/repository/PointHistoryRepository.java
@@ -1,0 +1,11 @@
+package shop.sajotuna.order.point.repository;
+
+import jakarta.validation.constraints.NotNull;
+import org.springframework.data.jpa.repository.JpaRepository;
+import shop.sajotuna.order.point.domain.PointHistory;
+
+import java.util.List;
+
+public interface PointHistoryRepository extends JpaRepository<PointHistory, Long> {
+    List<PointHistory> getPointHistoriesByUserId(@NotNull Long userId);
+}

--- a/src/main/java/shop/sajotuna/order/point/repository/PointPolicyRepository.java
+++ b/src/main/java/shop/sajotuna/order/point/repository/PointPolicyRepository.java
@@ -1,0 +1,9 @@
+package shop.sajotuna.order.point.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import shop.sajotuna.order.point.domain.PointPolicy;
+import shop.sajotuna.order.point.domain.PointPolicyType;
+
+public interface PointPolicyRepository extends JpaRepository<PointPolicy, Long> {
+    PointPolicy findByType(PointPolicyType type);
+}

--- a/src/main/java/shop/sajotuna/order/point/repository/UserPointRepository.java
+++ b/src/main/java/shop/sajotuna/order/point/repository/UserPointRepository.java
@@ -1,0 +1,10 @@
+package shop.sajotuna.order.point.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import shop.sajotuna.order.point.domain.UserPoint;
+
+import java.util.Optional;
+
+public interface UserPointRepository extends JpaRepository<UserPoint, Long> {
+    Optional<UserPoint> findByUserId(Long userId);
+}

--- a/src/main/java/shop/sajotuna/order/point/service/PointPolicyService.java
+++ b/src/main/java/shop/sajotuna/order/point/service/PointPolicyService.java
@@ -1,0 +1,9 @@
+package shop.sajotuna.order.point.service;
+
+public interface PointPolicyService {
+    int getPurchasePoint(int totalPrice);
+
+    int getReviewPoint();
+
+    int getRegisterPoint();
+}

--- a/src/main/java/shop/sajotuna/order/point/service/PointPolicyServiceImpl.java
+++ b/src/main/java/shop/sajotuna/order/point/service/PointPolicyServiceImpl.java
@@ -1,0 +1,35 @@
+package shop.sajotuna.order.point.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import shop.sajotuna.order.point.domain.PointPolicyType;
+import shop.sajotuna.order.point.repository.PointPolicyRepository;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+@Service
+@RequiredArgsConstructor
+public class PointPolicyServiceImpl implements PointPolicyService {
+
+    private final PointPolicyRepository pointPolicyRepository;
+
+    @Override
+    public int getPurchasePoint(int totalPrice) {
+        BigDecimal rate = pointPolicyRepository.findByType(PointPolicyType.PURCHASE).getRate();
+        BigDecimal price = BigDecimal.valueOf(totalPrice);
+
+        return price.multiply(rate).setScale(0, RoundingMode.DOWN).intValue();
+    }
+
+    @Override
+    public int getReviewPoint() {
+        return pointPolicyRepository.findByType(PointPolicyType.REVIEW).getFixedPoint();
+    }
+
+    @Override
+    public int getRegisterPoint() {
+        return pointPolicyRepository.findByType(PointPolicyType.REGISTER).getFixedPoint();
+    }
+
+}

--- a/src/main/java/shop/sajotuna/order/point/service/PointService.java
+++ b/src/main/java/shop/sajotuna/order/point/service/PointService.java
@@ -1,0 +1,18 @@
+package shop.sajotuna.order.point.service;
+
+
+import shop.sajotuna.order.point.controller.response.PointHistoryResponse;
+
+import java.util.List;
+
+public interface PointService {
+    List<PointHistoryResponse> getPointsByUserId(Long userId);
+
+    PointHistoryResponse earnPointsForPurchase(Long userId, int totalPrice);
+
+    PointHistoryResponse redeemPoints(Long userId, int pointAmount);
+
+    PointHistoryResponse earnPointsForReview(Long userId);
+
+    PointHistoryResponse earnPointsForRegistration(Long userId);
+}

--- a/src/main/java/shop/sajotuna/order/point/service/PointServiceImpl.java
+++ b/src/main/java/shop/sajotuna/order/point/service/PointServiceImpl.java
@@ -1,0 +1,78 @@
+package shop.sajotuna.order.point.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import shop.sajotuna.common.exception.UserPointNotFoundException;
+import shop.sajotuna.order.point.controller.response.PointHistoryResponse;
+import shop.sajotuna.order.point.domain.PointHistory;
+import shop.sajotuna.order.point.domain.PointType;
+import shop.sajotuna.order.point.domain.UserPoint;
+import shop.sajotuna.order.point.repository.PointHistoryRepository;
+import shop.sajotuna.order.point.repository.PointPolicyRepository;
+import shop.sajotuna.order.point.repository.UserPointRepository;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class PointServiceImpl implements PointService {
+
+    private final PointHistoryRepository pointHistoryRepository;
+    private final PointPolicyService pointPolicyService;
+    private final UserPointRepository userPointRepository;
+
+    @Override
+    public List<PointHistoryResponse> getPointsByUserId(Long userId) {
+        return pointHistoryRepository.getPointHistoriesByUserId(userId).stream()
+                .map(PointHistoryResponse::from)
+                .toList();
+    }
+
+    @Override
+    public PointHistoryResponse earnPointsForPurchase(Long userId, int totalPrice) {
+        UserPoint userPoint = userPointRepository.findByUserId(userId)
+                .orElseThrow(UserPointNotFoundException::new);
+
+        int earnedPoints = pointPolicyService.getPurchasePoint(totalPrice);
+
+        return getPointHistoryResponse(userId, userPoint, earnedPoints);
+    }
+
+    @Override
+    public PointHistoryResponse redeemPoints(Long userId, int pointAmount) {
+        UserPoint userPoint = userPointRepository.findByUserId(userId)
+                .orElseThrow(UserPointNotFoundException::new);
+
+        userPoint.redeemPoint(pointAmount);
+        PointHistory pointHistory = pointHistoryRepository.save(new PointHistory(userId, pointAmount, PointType.REDEEMED));
+        return PointHistoryResponse.from(pointHistory);
+    }
+
+    @Override
+    public PointHistoryResponse earnPointsForReview(Long userId) {
+        UserPoint userPoint = userPointRepository.findByUserId(userId)
+                .orElseThrow(UserPointNotFoundException::new);
+
+        int earnedPoints = pointPolicyService.getReviewPoint();
+
+        return getPointHistoryResponse(userId, userPoint, earnedPoints);
+    }
+
+    @Override
+    public PointHistoryResponse earnPointsForRegistration(Long userId) {
+        UserPoint userPoint = userPointRepository.findByUserId(userId)
+                .orElseThrow(UserPointNotFoundException::new);
+
+        int earnedPoints = pointPolicyService.getRegisterPoint();
+
+        return getPointHistoryResponse(userId, userPoint, earnedPoints);
+    }
+
+    private PointHistoryResponse getPointHistoryResponse(Long userId, UserPoint userPoint, int earnedPoints) {
+        userPoint.earnPoint(earnedPoints);
+        PointHistory pointHistory = pointHistoryRepository.save(new PointHistory(userId, earnedPoints, PointType.EARNED));
+        return PointHistoryResponse.from(pointHistory);
+    }
+}

--- a/src/main/java/shop/sajotuna/order/point/service/PointServiceImpl.java
+++ b/src/main/java/shop/sajotuna/order/point/service/PointServiceImpl.java
@@ -9,7 +9,6 @@ import shop.sajotuna.order.point.domain.PointHistory;
 import shop.sajotuna.order.point.domain.PointType;
 import shop.sajotuna.order.point.domain.UserPoint;
 import shop.sajotuna.order.point.repository.PointHistoryRepository;
-import shop.sajotuna.order.point.repository.PointPolicyRepository;
 import shop.sajotuna.order.point.repository.UserPointRepository;
 
 import java.util.List;


### PR DESCRIPTION
## 변경 사항
- 최상위 ApiException을 정의하고, 커스텀 예외는 해당 예외를 상속받아 사용
- 관리자가 포인트 정책을 수정할 수 있도록 PointPolicy Entity 생성
- 회원 포인트의 정확한 관리를 위해 UserPoint Entity로 관리
- PointService는 PointPolicyService에서 상황에 따른 포인트 정책을 가져옴
- 구매 적립의 적립률은 소수점 아래 2자리까지 허용
- 정확한 소수점 계산을 위한 BigDecimal 사용

## 관련 이슈
closed #3 

