### PR TITLE
[feat] : 포인트 적립 메시지 큐 적용

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,35 @@
             <artifactId>h2</artifactId>
             <scope>runtime</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-amqp</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.amqp</groupId>
+            <artifactId>spring-rabbit-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>rabbitmq</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>mysql</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/shop/sajotuna/order/OrderApplication.java
+++ b/src/main/java/shop/sajotuna/order/OrderApplication.java
@@ -2,8 +2,10 @@ package shop.sajotuna.order;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 
 @SpringBootApplication
+@ConfigurationPropertiesScan
 public class OrderApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/shop/sajotuna/order/common/rabbitmq/RabbitMqConfig.java
+++ b/src/main/java/shop/sajotuna/order/common/rabbitmq/RabbitMqConfig.java
@@ -1,0 +1,68 @@
+package shop.sajotuna.order.common.rabbitmq;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.amqp.core.Binding;
+import org.springframework.amqp.core.BindingBuilder;
+import org.springframework.amqp.core.DirectExchange;
+import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
+import org.springframework.amqp.support.converter.MessageConverter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@RequiredArgsConstructor
+@Configuration
+public class RabbitMqConfig {
+
+    private final RabbitMqProperties rabbitMqProperties;
+
+    @Value("${rabbitmq.queue.name}")
+    private String queueName;
+
+    @Value("${rabbitmq.exchange.name}")
+    private String exchangeName;
+
+    @Value("${rabbitmq.routing.key}")
+    private String routingKey;
+
+    @Bean
+    public Queue queue() {
+        return new Queue(queueName);
+    }
+
+    @Bean
+    public DirectExchange directExchange() {
+        return new DirectExchange(exchangeName);
+    }
+
+    @Bean
+    public Binding binding(Queue queue, DirectExchange exchange) {
+        return BindingBuilder.bind(queue).to(exchange).with(routingKey);
+    }
+
+    @Bean
+    public CachingConnectionFactory connectionFactory() {
+        CachingConnectionFactory connectionFactory = new CachingConnectionFactory();
+        connectionFactory.setHost(rabbitMqProperties.getHost());
+        connectionFactory.setPort(rabbitMqProperties.getPort());
+        connectionFactory.setUsername(rabbitMqProperties.getUsername());
+        connectionFactory.setPassword(rabbitMqProperties.getPassword());
+        return connectionFactory;
+    }
+
+    @Bean
+    public RabbitTemplate rabbitTemplate(ConnectionFactory connectionFactory) {
+        RabbitTemplate rabbitTemplate = new RabbitTemplate(connectionFactory);
+        rabbitTemplate.setMessageConverter(jackson2JsonMessageConverter());
+        return rabbitTemplate;
+    }
+
+    @Bean
+    public MessageConverter jackson2JsonMessageConverter() {
+        return new Jackson2JsonMessageConverter();
+    }
+}

--- a/src/main/java/shop/sajotuna/order/common/rabbitmq/RabbitMqProperties.java
+++ b/src/main/java/shop/sajotuna/order/common/rabbitmq/RabbitMqProperties.java
@@ -1,0 +1,15 @@
+package shop.sajotuna.order.common.rabbitmq;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "spring.rabbitmq")
+@AllArgsConstructor
+@Getter
+public class RabbitMqProperties {
+    private String host;
+    private int port;
+    private String username;
+    private String password;
+}

--- a/src/main/java/shop/sajotuna/order/orders/service/OrderService.java
+++ b/src/main/java/shop/sajotuna/order/orders/service/OrderService.java
@@ -1,6 +1,8 @@
 package shop.sajotuna.order.orders.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import shop.sajotuna.order.coupon.service.UserCouponService;
@@ -9,6 +11,8 @@ import shop.sajotuna.order.orders.entity.*;
 import shop.sajotuna.order.orders.repository.*;
 import shop.sajotuna.order.payment.entity.Payment;
 import shop.sajotuna.order.payment.repository.PaymentRepository;
+import shop.sajotuna.order.point.controller.request.PointEarnRequest;
+import shop.sajotuna.order.point.domain.PointPolicyType;
 import shop.sajotuna.order.point.exception.OrderNotFoundException;
 import shop.sajotuna.order.point.service.PointService;
 
@@ -24,6 +28,14 @@ public class OrderService {
     private final PointService pointService;
     private final UserCouponService userCouponService;
     private final OrderProductService orderProductService;
+
+    @Value("${rabbitmq.exchange.name}")
+    private String exchangeName;
+
+    @Value("${rabbitmq.routing.key}")
+    private String routingKey;
+
+    private final RabbitTemplate rabbitTemplate;
 
     // 주문 조회
     public OrderDetailResponse findOrderDetail(long orderId){
@@ -68,7 +80,7 @@ public class OrderService {
         paymentRepository.save(payment);
 
         // 포인트 적립
-        pointService.earnPointsForPurchase(userId, paymentPrice);
+        rabbitTemplate.convertAndSend(exchangeName, routingKey, new PointEarnRequest(userId, paymentPrice, PointPolicyType.PURCHASE));
 
         return OrderResponse.from(savedOrder);
     }

--- a/src/main/java/shop/sajotuna/order/point/controller/PointController.java
+++ b/src/main/java/shop/sajotuna/order/point/controller/PointController.java
@@ -20,22 +20,4 @@ public class PointController {
     public ResponseEntity<List<PointHistoryResponse>> getPointsByUserId(@RequestHeader("X-User-Id") Long userId) {
         return ResponseEntity.ok(pointService.getPointsByUserId(userId));
     }
-
-    /**
-     * 리뷰 작성시 호출하는 API
-     * 호출 시 RequestParam으로 PointPolicyType을 전달받아 해당 정책에 따라 포인트를 적립합니다.
-     */
-    @PostMapping("/review")
-    public ResponseEntity<PointHistoryResponse> getPointsByReview(@RequestHeader("X-User-Id") Long userId, @RequestParam PointPolicyType type) {
-        return ResponseEntity.ok(pointService.earnPointsByReview(userId, type));
-    }
-
-    /**
-     * 회원 가입 시 호출하는 API
-     * 호출 시 UserPoint 테이블에 새로운 컬럼이 생성됩니다.
-     */
-    @PostMapping("/register")
-    public ResponseEntity<PointHistoryResponse> getPointsByRegister(Long userId) {
-        return ResponseEntity.ok(pointService.earnPointsByRegister(userId));
-    }
 }

--- a/src/main/java/shop/sajotuna/order/point/controller/request/PointEarnRequest.java
+++ b/src/main/java/shop/sajotuna/order/point/controller/request/PointEarnRequest.java
@@ -1,0 +1,13 @@
+package shop.sajotuna.order.point.controller.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import shop.sajotuna.order.point.domain.PointPolicyType;
+
+@AllArgsConstructor
+@Getter
+public class PointEarnRequest {
+    private Long userId;
+    private int totalPrice;
+    private PointPolicyType type;
+}

--- a/src/main/java/shop/sajotuna/order/point/service/PointEarnEventListener.java
+++ b/src/main/java/shop/sajotuna/order/point/service/PointEarnEventListener.java
@@ -1,0 +1,23 @@
+package shop.sajotuna.order.point.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.stereotype.Service;
+import shop.sajotuna.order.point.controller.request.PointEarnRequest;
+import shop.sajotuna.order.point.domain.PointPolicyType;
+
+@Service
+@RequiredArgsConstructor
+public class PointEarnEventListener {
+
+    private final PointService pointService;
+
+    @RabbitListener(queues = "${rabbitmq.queue.name}")
+    public void earnPoints(PointEarnRequest request) {
+        if (request.getType() == PointPolicyType.PURCHASE) {
+            pointService.earnPointsForPurchase(request.getUserId(), request.getTotalPrice());
+            return;
+        }
+        pointService.earnPointsByType(request.getUserId(), request.getType());
+    }
+}

--- a/src/main/java/shop/sajotuna/order/point/service/PointService.java
+++ b/src/main/java/shop/sajotuna/order/point/service/PointService.java
@@ -9,11 +9,10 @@ import java.util.List;
 public interface PointService {
     List<PointHistoryResponse> getPointsByUserId(Long userId);
 
-    PointHistoryResponse earnPointsForPurchase(Long userId, int totalPrice);
+    void earnPointsForPurchase(Long userId, int totalPrice);
 
     PointHistoryResponse redeemPoints(Long userId, int pointAmount);
 
-    PointHistoryResponse earnPointsByReview(Long userId, PointPolicyType type);
+    void earnPointsByType(Long userId, PointPolicyType type);
 
-    PointHistoryResponse earnPointsByRegister(Long userId);
 }

--- a/src/main/java/shop/sajotuna/order/point/service/PointServiceImpl.java
+++ b/src/main/java/shop/sajotuna/order/point/service/PointServiceImpl.java
@@ -29,7 +29,7 @@ public class PointServiceImpl implements PointService {
     }
 
     @Override
-    public PointHistoryResponse earnPointsForPurchase(Long userId, int totalPrice) {
+    public void earnPointsForPurchase(Long userId, int totalPrice) {
         UserPoint userPoint = userPointRepository.findByUserId(userId)
                 .orElseThrow(UserPointNotFoundException::new);
 
@@ -37,7 +37,25 @@ public class PointServiceImpl implements PointService {
         int earnedPoints = pointPolicy.calculatePoint(totalPrice);
         userPoint.earnPoint(earnedPoints);
 
-        return getPointHistoryResponse(userId, earnedPoints);
+        pointHistoryRepository.save(PointHistory.createEarnHistory(userId, earnedPoints));
+    }
+
+    @Override
+    public void earnPointsByType(Long userId, PointPolicyType type) {
+        UserPoint userPoint;
+        if (type == PointPolicyType.REGISTER) {
+            userPoint = UserPoint.create(userId);
+            userPointRepository.save(userPoint);
+        } else {
+            userPoint = userPointRepository.findByUserId(userId)
+                    .orElseThrow(UserPointNotFoundException::new);
+        }
+
+        PointPolicy pointPolicy = pointPolicyService.getPointPolicy(type);
+        int earnedPoints = pointPolicy.getFixedPoint();
+        userPoint.earnPoint(earnedPoints);
+
+        pointHistoryRepository.save(PointHistory.createEarnHistory(userId, earnedPoints));
     }
 
     @Override
@@ -47,35 +65,6 @@ public class PointServiceImpl implements PointService {
 
         userPoint.redeemPoint(pointAmount);
         PointHistory pointHistory = pointHistoryRepository.save(PointHistory.createRedeemHistory(userId, pointAmount));
-        return PointHistoryResponse.from(pointHistory);
-    }
-
-    @Override
-    public PointHistoryResponse earnPointsByReview(Long userId, PointPolicyType type) {
-        UserPoint userPoint = userPointRepository.findByUserId(userId)
-                .orElseThrow(UserPointNotFoundException::new);
-
-        PointPolicy pointPolicy = pointPolicyService.getPointPolicy(type);
-        int earnedPoints = pointPolicy.getFixedPoint();
-        userPoint.earnPoint(earnedPoints);
-
-        return getPointHistoryResponse(userId, earnedPoints);
-    }
-
-    @Override
-    public PointHistoryResponse earnPointsByRegister(Long userId) {
-        UserPoint userPoint = UserPoint.create(userId);
-        userPointRepository.save(userPoint);
-
-        PointPolicy pointPolicy = pointPolicyService.getPointPolicy(PointPolicyType.REGISTER);
-        int earnedPoints = pointPolicy.getFixedPoint();
-        userPoint.earnPoint(earnedPoints);
-
-        return getPointHistoryResponse(userId, earnedPoints);
-    }
-
-    private PointHistoryResponse getPointHistoryResponse(Long userId, int earnedPoints) {
-        PointHistory pointHistory = pointHistoryRepository.save(PointHistory.createEarnHistory(userId, earnedPoints));
         return PointHistoryResponse.from(pointHistory);
     }
 }

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -5,4 +5,4 @@ spring:
     import: configserver:http://localhost:10379
   cloud:
     config:
-      lable: dev
+      label: dev

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -1,0 +1,46 @@
+spring:
+  # 테스트 전용 H2 (인메모리)
+  datasource:
+    url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+
+  # RabbitMQ (Testcontainers가 localhost:5672에 띄워 준다고 가정)
+  rabbitmq:
+    host: localhost
+    port: 5672
+    username: guest
+    password: guest
+
+  # Config Server 비활성화
+  cloud:
+    config:
+      enabled: false
+
+  jpa:
+    open-in-view: false
+    show-sql: true
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        format_sql: true
+        use_sql_comments: true
+        highlight_sql: true
+        auto_quote_keyword: true
+
+# 포인트 큐/익스체인지 설정도 여기로
+rabbitmq:
+  exchange:
+    name: point-exchange
+  routing:
+    key: point.earn
+  queue:
+    name: point-queue
+
+logging:
+  level:
+    com.netflix.discovery: off
+    com.netflix.eureka: off
+    org.springframework.cloud.netflix.eureka: off

--- a/src/test/java/shop/sajotuna/order/point/service/PointServiceImplTest.java
+++ b/src/test/java/shop/sajotuna/order/point/service/PointServiceImplTest.java
@@ -1,0 +1,158 @@
+package shop.sajotuna.order.point.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+import shop.sajotuna.order.point.controller.response.PointHistoryResponse;
+import shop.sajotuna.order.point.domain.PointPolicyType;
+import shop.sajotuna.order.point.domain.PointType;
+import shop.sajotuna.order.point.domain.UserPoint;
+import shop.sajotuna.order.point.exception.InsufficientPointException;
+import shop.sajotuna.order.point.exception.UserPointNotFoundException;
+import shop.sajotuna.order.point.repository.PointHistoryRepository;
+import shop.sajotuna.order.point.repository.UserPointRepository;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+class PointServiceImplTest {
+
+    private static final Long USER_ID = 100L;
+    private static final int PURCHASE_AMOUNT = 5000;
+
+    @Autowired
+    private PointService pointService;
+
+    @Autowired
+    private PointPolicyService pointPolicyService;
+
+    @Autowired
+    private UserPointRepository userPointRepository;
+
+    @Autowired
+    private PointHistoryRepository pointHistoryRepository;
+
+    @BeforeEach
+    void setUp() {
+        pointHistoryRepository.deleteAll();
+        userPointRepository.deleteAll();
+
+        userPointRepository.save(UserPoint.create(USER_ID));
+    }
+
+    @Test
+    void earnPointsForPurchase_shouldIncreaseRemainAndCreateHistory() {
+        // given
+        int expectedEarn = pointPolicyService
+                .getPointPolicy(PointPolicyType.PURCHASE)
+                .calculatePoint(PURCHASE_AMOUNT);
+
+        // when: 두 번 연속 호출
+        pointService.earnPointsForPurchase(USER_ID, PURCHASE_AMOUNT);
+        pointService.earnPointsForPurchase(USER_ID, PURCHASE_AMOUNT);
+
+        // then: remainPoint, version, 히스토리 레코드 확인
+        UserPoint up = userPointRepository.findByUserId(USER_ID).orElseThrow();
+        assertThat(up.getRemainPoint()).isEqualTo(expectedEarn * 2L);
+        assertThat(up.getVersion()).isEqualTo(2);
+
+        List<PointHistoryResponse> histories = pointService.getPointsByUserId(USER_ID);
+        assertThat(histories).hasSize(2)
+                .allMatch(h -> h.getAmount() == expectedEarn)
+                .extracting(PointHistoryResponse::getType)
+                .allMatch(t -> t == PointType.EARNED);
+    }
+
+    @Test
+    void earnPointsByType_register_shouldCreateNewAndHistory() {
+        // given
+        userPointRepository.deleteAll();
+
+        int expected = pointPolicyService
+                .getPointPolicy(PointPolicyType.REGISTER)
+                .getFixedPoint();
+
+        // when
+        pointService.earnPointsByType(USER_ID, PointPolicyType.REGISTER);
+
+        // then
+        UserPoint up = userPointRepository.findByUserId(USER_ID).orElseThrow();
+        assertThat(up.getRemainPoint()).isEqualTo(expected);
+        assertThat(up.getVersion()).isEqualTo(1);
+
+        List<PointHistoryResponse> histories = pointService.getPointsByUserId(USER_ID);
+        assertThat(histories).hasSize(1)
+                .first()
+                .satisfies(history -> {
+                    assertThat(history.getAmount()).isEqualTo(expected);
+                    assertThat(history.getType()).isEqualTo(PointType.EARNED);
+                });
+    }
+
+    @Test
+    void earnPointsByType_otherType_shouldAccumulate() {
+        // given
+        Long before = userPointRepository.findByUserId(USER_ID).get().getRemainPoint();
+        int expected = pointPolicyService
+                .getPointPolicy(PointPolicyType.REVIEW)
+                .getFixedPoint();
+
+        // when
+        pointService.earnPointsByType(USER_ID, PointPolicyType.REVIEW);
+
+        // then
+        UserPoint up = userPointRepository.findByUserId(USER_ID).get();
+        assertThat(up.getRemainPoint()).isEqualTo(before + expected);
+        assertThat(up.getVersion()).isEqualTo(1);
+
+        List<PointHistoryResponse> histories = pointService.getPointsByUserId(USER_ID);
+        assertThat(histories).hasSize(1)
+                .first()
+                .satisfies(h -> {
+                    assertThat(h.getAmount()).isEqualTo(expected);
+                    assertThat(h.getType()).isEqualTo(PointType.EARNED);
+                });
+    }
+
+    @Test
+    void redeemPoints_withSufficientRemain_shouldDeductAndCreateHistory() {
+        pointService.earnPointsForPurchase(USER_ID, PURCHASE_AMOUNT);
+        int toRedeem = pointPolicyService
+                .getPointPolicy(PointPolicyType.PURCHASE)
+                .calculatePoint(PURCHASE_AMOUNT);
+
+        // when
+        PointHistoryResponse resp = pointService.redeemPoints(USER_ID, toRedeem);
+
+        // then
+        UserPoint up = userPointRepository.findByUserId(USER_ID).get();
+        assertThat(up.getRemainPoint()).isZero();
+        assertThat(up.getVersion()).isEqualTo(2);
+
+        List<PointHistoryResponse> histories = pointService.getPointsByUserId(USER_ID);
+        assertThat(histories).hasSize(2);
+        assertThat(histories.get(1).getType()).isEqualTo(PointType.REDEEMED);
+        assertThat(histories.get(1).getAmount()).isEqualTo(toRedeem);
+    }
+
+    @Test
+    void redeemPoints_whenInsufficient_shouldThrow() {
+        assertThatThrownBy(() -> pointService.redeemPoints(USER_ID, 1))
+                .isInstanceOf(InsufficientPointException.class);
+    }
+
+    @Test
+    void operations_onNonexistentUser_shouldThrow() {
+        assertThatThrownBy(() -> pointService.earnPointsForPurchase(999L, 1000))
+                .isInstanceOf(UserPointNotFoundException.class);
+        assertThatThrownBy(() -> pointService.redeemPoints(999L, 1))
+                .isInstanceOf(UserPointNotFoundException.class);
+    }
+}

--- a/src/test/java/shop/sajotuna/order/point/service/PointServiceQueueConcurrencyTest.java
+++ b/src/test/java/shop/sajotuna/order/point/service/PointServiceQueueConcurrencyTest.java
@@ -1,0 +1,113 @@
+package shop.sajotuna.order.point.service;
+
+import com.github.dockerjava.api.model.ExposedPort;
+import com.github.dockerjava.api.model.PortBinding;
+import com.github.dockerjava.api.model.Ports;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.testcontainers.containers.RabbitMQContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import shop.sajotuna.order.point.controller.request.PointEarnRequest;
+import shop.sajotuna.order.point.domain.PointPolicyType;
+import shop.sajotuna.order.point.domain.UserPoint;
+import shop.sajotuna.order.point.repository.UserPointRepository;
+
+import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@Testcontainers
+@SpringBootTest
+@ActiveProfiles("test")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class PointServiceQueueConcurrencyTest {
+
+    private static final int THREADS         = 50;
+    private static final Long USER_ID        = 42L;
+    private static final int PURCHASE_AMOUNT = 10_000;
+
+    @Container
+    static RabbitMQContainer rabbitmq =
+            new RabbitMQContainer("rabbitmq:3-management-alpine")
+                    .withExposedPorts(5672)
+                    .waitingFor(Wait.forListeningPort())
+                    .withCreateContainerCmdModifier(cmd ->
+                            cmd.getHostConfig()
+                                    .withPortBindings(
+                                            new PortBinding(
+                                                    Ports.Binding.bindPort(5672),
+                                                    new ExposedPort(5672)
+                                            )
+                                    )
+                    );
+
+    @Autowired
+    private RabbitTemplate rabbitTemplate;
+
+    @Autowired
+    private UserPointRepository userPointRepository;
+
+    @Autowired
+    private PointPolicyService pointPolicyService;
+
+    @BeforeEach
+    void setUp() {
+        rabbitTemplate.execute(ch -> {
+            ch.queuePurge("point-queue");
+            return null;
+        });
+        userPointRepository.deleteAll();
+        userPointRepository.save(UserPoint.create(USER_ID));
+    }
+
+    @Test
+    void concurrentEarningViaQueue_shouldAccumulateWithoutLostUpdates() throws InterruptedException {
+        int perEarn = pointPolicyService
+                .getPointPolicy(PointPolicyType.PURCHASE)
+                .calculatePoint(PURCHASE_AMOUNT);
+
+        ExecutorService executor = Executors.newFixedThreadPool(THREADS);
+        CountDownLatch latch = new CountDownLatch(THREADS);
+
+        String exchange   = "point-exchange";
+        String routingKey = "point.earn";
+
+        for (int i = 0; i < THREADS; i++) {
+            executor.submit(() -> {
+                try {
+                    rabbitTemplate.convertAndSend(
+                            exchange,
+                            routingKey,
+                            new PointEarnRequest(USER_ID, PURCHASE_AMOUNT, PointPolicyType.PURCHASE)
+                    );
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+
+        Awaitility.await()
+                .atMost(Duration.ofSeconds(10))
+                .untilAsserted(() -> {
+                    UserPoint up = userPointRepository.findByUserId(USER_ID)
+                            .orElseThrow();
+                    assertEquals(perEarn * THREADS, up.getRemainPoint());
+                    assertEquals(THREADS, up.getVersion());
+                });
+
+        executor.shutdown();
+    }
+}

--- a/src/test/java/shop/sajotuna/order/point/service/PointServiceQueueConcurrencyTest.java
+++ b/src/test/java/shop/sajotuna/order/point/service/PointServiceQueueConcurrencyTest.java
@@ -30,7 +30,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 @Testcontainers
 @SpringBootTest
 @ActiveProfiles("test")
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class PointServiceQueueConcurrencyTest {
 
     private static final int THREADS         = 50;


### PR DESCRIPTION


## 변경 사항
- RabbitMQ 설정 및 Config 추가
- 포인트 적립 RabbitMQ 적용
- PointEarnEventListener가 포인트 적립에 관한 Consumer로 동작하도록 구현
- 해당 Listener가 PointPolicyType에 따라 PointService를 호출하여 적립 처리
- 테스트 환경을 위한 TestContainer 의존성 추가 및 application-test.yml 추가
- PointService 테스트 구현

## 관련 이슈

#29 
