### PR TITLE
[feat] : 배송비 정책 추가

### DIFF
--- a/http/coupon.http
+++ b/http/coupon.http
@@ -1,5 +1,5 @@
 ### 쿠폰 발급
-POST localhost:10366/api/coupons
+POST localhost:10366/api/admin/coupons
 Content-Type: application/json
 
 {
@@ -18,6 +18,6 @@ Content-Type: application/json
 
 {
   "userId": 1,
-  "couponId": 2,
+  "couponId": 5,
   "issuedAt": "20250620151112"
 }

--- a/http/orders.http
+++ b/http/orders.http
@@ -25,7 +25,6 @@ X-User-Id: 1
   "recipientEmail": "kim@example.com",
   "recipientAddress": "서울시 강남구 테헤란로 123",
   "shippingDate": "20250730081219",
-  "deliveryPrice": 1000,
   "paymentMethod": "CARD",
   "orderCouponId": 1,
   "usedPoint": 1000,

--- a/src/main/java/shop/sajotuna/order/common/initializer/DeliveryPriceInitializer.java
+++ b/src/main/java/shop/sajotuna/order/common/initializer/DeliveryPriceInitializer.java
@@ -1,0 +1,24 @@
+package shop.sajotuna.order.common.initializer;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Component;
+import shop.sajotuna.order.common.domain.Money;
+import shop.sajotuna.order.orders.domain.DeliveryPrice;
+import shop.sajotuna.order.orders.repository.DeliveryPriceRepository;
+
+@Component
+@RequiredArgsConstructor
+public class DeliveryPriceInitializer implements ApplicationRunner {
+
+    private final DeliveryPriceRepository deliveryPriceRepository;
+
+    @Override
+    public void run(ApplicationArguments args) throws Exception {
+        if (deliveryPriceRepository.count() == 0) {
+            DeliveryPrice deliveryPrice = new DeliveryPrice(null, Money.of(30000), Money.of(5000));
+            deliveryPriceRepository.save(deliveryPrice);
+        }
+    }
+}

--- a/src/main/java/shop/sajotuna/order/orders/controller/dto/request/CreateOrderRequest.java
+++ b/src/main/java/shop/sajotuna/order/orders/controller/dto/request/CreateOrderRequest.java
@@ -50,10 +50,6 @@ public class CreateOrderRequest {
     private LocalDateTime shippingDate;
 
     @NotNull
-    @Min(0)
-    private Integer deliveryPrice;
-
-    @NotNull
     private PaymentMethod paymentMethod;
 
     private Long orderCouponId;
@@ -69,7 +65,6 @@ public class CreateOrderRequest {
         return CreateOrderCommand.builder()
                 .orderer(toOrderer(userId))
                 .shippingInfo(toShippingInfo())
-                .deliveryPrice(Money.of(deliveryPrice))
                 .paymentMethod(paymentMethod)
                 .orderCouponId(orderCouponId)
                 .usedPoint(Money.of(usedPoint))

--- a/src/main/java/shop/sajotuna/order/orders/domain/DeliveryPrice.java
+++ b/src/main/java/shop/sajotuna/order/orders/domain/DeliveryPrice.java
@@ -1,0 +1,36 @@
+package shop.sajotuna.order.orders.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import shop.sajotuna.order.common.domain.Money;
+import shop.sajotuna.order.common.exception.NullValueException;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter
+public class DeliveryPrice {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @AttributeOverride(name = "amount", column = @Column(name = "free_delivery_min_price", nullable = false))
+    private Money freeDeliveryMinPrice;
+
+    @AttributeOverride(name = "amount", column = @Column(name = "delivery_price", nullable = false))
+    private Money deliveryPrice;
+
+    public Money calculateDeliveryPrice(Money orderPrice) {
+        if (orderPrice == null) {
+            throw new NullValueException("주문 가격은 null일 수 없습니다.");
+        }
+        if (orderPrice.isGreaterThanOrEqual(freeDeliveryMinPrice)) {
+            return Money.zero();
+        }
+        return deliveryPrice;
+    }
+}

--- a/src/main/java/shop/sajotuna/order/orders/domain/Discounts.java
+++ b/src/main/java/shop/sajotuna/order/orders/domain/Discounts.java
@@ -1,10 +1,12 @@
 package shop.sajotuna.order.orders.domain;
 
 import jakarta.persistence.*;
+import jakarta.validation.constraints.Null;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import shop.sajotuna.order.common.domain.Money;
+import shop.sajotuna.order.common.exception.NullValueException;
 
 @Getter
 @Embeddable
@@ -12,15 +14,11 @@ import shop.sajotuna.order.common.domain.Money;
 public class Discounts {
 
     @Embedded
-    @AttributeOverrides({
-            @AttributeOverride(name = "amount", column = @Column(name = "coupon_discount_amount"))
-    })
+    @AttributeOverride(name = "amount", column = @Column(name = "coupon_discount_amount"))
     private Money couponDiscountAmount;
 
     @Embedded
-    @AttributeOverrides({
-            @AttributeOverride(name = "amount", column = @Column(name = "used_point"))
-    })
+    @AttributeOverride(name = "amount", column = @Column(name = "used_point"))
     private Money usedPoint;
 
     public Discounts(Money couponDiscountAmount, Money usedPoint) {
@@ -31,10 +29,10 @@ public class Discounts {
 
     private void validateDiscounts(Money couponDiscountAmount, Money usedPoint) {
         if (couponDiscountAmount == null) {
-            throw new IllegalArgumentException("쿠폰 할인 금액은 필수입니다.");
+            throw new NullValueException("쿠폰 할인 금액은 필수입니다.");
         }
         if (usedPoint == null) {
-            throw new IllegalArgumentException("사용한 포인트는 필수입니다.");
+            throw new NullValueException("사용한 포인트는 필수입니다.");
         }
     }
 

--- a/src/main/java/shop/sajotuna/order/orders/domain/Order.java
+++ b/src/main/java/shop/sajotuna/order/orders/domain/Order.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.*;
 import org.apache.commons.lang.RandomStringUtils;
 import shop.sajotuna.order.common.domain.Money;
+import shop.sajotuna.order.common.exception.NullValueException;
 import shop.sajotuna.order.orders.exception.InvalidStatusException;
 import shop.sajotuna.order.orders.exception.TimeOutException;
 
@@ -56,7 +57,7 @@ public class Order {
     private void addOrderProduct(List<OrderProduct> orderProducts) {
         for (OrderProduct orderProduct : orderProducts) {
             if (orderProduct == null) {
-                throw new IllegalArgumentException("주문 상품은 null일 수 없습니다.");
+                throw new NullValueException("주문 상품은 null일 수 없습니다.");
             }
             orderProduct.setOrder(this);
             this.orderProducts.add(orderProduct);

--- a/src/main/java/shop/sajotuna/order/orders/repository/DeliveryPriceRepository.java
+++ b/src/main/java/shop/sajotuna/order/orders/repository/DeliveryPriceRepository.java
@@ -5,7 +5,9 @@ import shop.sajotuna.order.orders.domain.DeliveryPrice;
 
 public interface DeliveryPriceRepository extends JpaRepository<DeliveryPrice, Long> {
 
+    long DEFAULT_DELIVERY_PRICE_ID = 1L;
+
     default DeliveryPrice getDefaultDeliveryPrice() {
-        return findById(1L).get();
+        return findById(DEFAULT_DELIVERY_PRICE_ID).get();
     }
 }

--- a/src/main/java/shop/sajotuna/order/orders/repository/DeliveryPriceRepository.java
+++ b/src/main/java/shop/sajotuna/order/orders/repository/DeliveryPriceRepository.java
@@ -1,0 +1,11 @@
+package shop.sajotuna.order.orders.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import shop.sajotuna.order.orders.domain.DeliveryPrice;
+
+public interface DeliveryPriceRepository extends JpaRepository<DeliveryPrice, Long> {
+
+    default DeliveryPrice getDefaultDeliveryPrice() {
+        return findById(1L).get();
+    }
+}

--- a/src/main/java/shop/sajotuna/order/orders/service/DiscountService.java
+++ b/src/main/java/shop/sajotuna/order/orders/service/DiscountService.java
@@ -2,6 +2,7 @@ package shop.sajotuna.order.orders.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import shop.sajotuna.order.common.domain.Money;
 import shop.sajotuna.order.coupon.domain.UserCoupon;
 import shop.sajotuna.order.coupon.exception.CouponNotFoundException;
@@ -20,6 +21,7 @@ public class DiscountService {
     private final UserCouponRepository userCouponRepository;
     private final PointHistoryWriter pointHistoryWriter;
 
+    @Transactional
     public Discounts discount(Long orderCouponId, Money usedPoint, Long userId, Money totalProductPrice) {
         Money couponDiscountAmount = Money.zero();
         if (orderCouponId != null) {
@@ -29,7 +31,7 @@ public class DiscountService {
 
         if (usedPoint.isPositive()) {
             UserPoint userPoint = getUserPointByUserId(userId);
-             userPoint.redeemPoint(usedPoint);
+            userPoint.redeemPoint(usedPoint);
             pointHistoryWriter.savePointRedeemHistory(userId, usedPoint);
         }
         return new Discounts(couponDiscountAmount, usedPoint);

--- a/src/main/java/shop/sajotuna/order/orders/service/OrderProcessService.java
+++ b/src/main/java/shop/sajotuna/order/orders/service/OrderProcessService.java
@@ -29,13 +29,13 @@ public class OrderProcessService {
     public OrderResponse processUserOrder(CreateOrderCommand command) {
 
         List<OrderProduct> orderProducts = orderProductCreateService.createOrderProducts(command.getItems());
-        OrderPrice orderPrice = pricingService.calculatePrices(orderProducts, command.getDeliveryPrice());
+        OrderPrice orderPrice = pricingService.calculatePrices(orderProducts);
         Discounts discounts = discountService.discount(command.getOrderCouponId(), command.getUsedPoint(), command.getUserId(), orderPrice.getTotalProductPrice());
 
         Order order = Order.createOrder(command.getOrderer(), command.getShippingInfo(), orderPrice, discounts, orderProducts);
         orderRepository.save(order);
 
-        pointQueueService.sendEarnPointsMessage(command.getUserId(), PointPolicyType.PURCHASE, order.getFinalPrice());
+        pointQueueService.sendEarnPointsMessage(command.getUserId(), PointPolicyType.PURCHASE, order.getFinalProductPrice());
 
         return OrderResponse.from(order);
     }

--- a/src/main/java/shop/sajotuna/order/orders/service/OrderProductCreateService.java
+++ b/src/main/java/shop/sajotuna/order/orders/service/OrderProductCreateService.java
@@ -2,6 +2,7 @@ package shop.sajotuna.order.orders.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import shop.sajotuna.order.orders.domain.OrderPackaging;
 import shop.sajotuna.order.orders.domain.OrderProduct;
 import shop.sajotuna.order.orders.exception.PackageNotFoundException;
@@ -16,6 +17,7 @@ public class OrderProductCreateService {
 
     private final OrderPackagingRepository orderPackagingRepository;
 
+    @Transactional(readOnly = true)
     public List<OrderProduct> createOrderProducts(List<CreateOrderProductCommand> productCommands) {
         return productCommands.stream()
                 .map(this::createOrderProduct)

--- a/src/main/java/shop/sajotuna/order/orders/service/OrderProductService.java
+++ b/src/main/java/shop/sajotuna/order/orders/service/OrderProductService.java
@@ -40,6 +40,7 @@ public class OrderProductService {
     }
 
     // 특정 주문 번호에 포함된 상품들 삭제
+    @Transactional
     public void deleteByOrderId(Long orderId){
         if(!orderRepository.existsById(orderId)){
             throw new OrderNotFoundException();

--- a/src/main/java/shop/sajotuna/order/orders/service/OrderTotalPriceService.java
+++ b/src/main/java/shop/sajotuna/order/orders/service/OrderTotalPriceService.java
@@ -2,6 +2,7 @@ package shop.sajotuna.order.orders.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import shop.sajotuna.order.common.domain.Money;
 import shop.sajotuna.order.orders.domain.Order;
 import shop.sajotuna.order.orders.repository.OrderRepository;
@@ -16,6 +17,7 @@ public class OrderTotalPriceService {
     private final OrderRepository orderRepository;
 
     // 3개월 간 순수 주문 금액 계산
+    @Transactional(readOnly = true)
     public Money calculateTotalOrderAmount(Long userId) {
         LocalDateTime threeMonthsAgo = LocalDateTime.now().minusMonths(3);
         List<Order> orders = orderRepository.findByOrdererUserIdAndCreatedAtAfter(userId, threeMonthsAgo);

--- a/src/main/java/shop/sajotuna/order/orders/service/PricingService.java
+++ b/src/main/java/shop/sajotuna/order/orders/service/PricingService.java
@@ -2,9 +2,12 @@ package shop.sajotuna.order.orders.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import shop.sajotuna.order.common.domain.Money;
+import shop.sajotuna.order.orders.domain.DeliveryPrice;
 import shop.sajotuna.order.orders.domain.OrderProduct;
 import shop.sajotuna.order.orders.domain.OrderPrice;
+import shop.sajotuna.order.orders.repository.DeliveryPriceRepository;
 
 import java.util.List;
 
@@ -12,7 +15,10 @@ import java.util.List;
 @RequiredArgsConstructor
 public class PricingService {
 
-    public OrderPrice calculatePrices(List<OrderProduct> orderProducts, Money deliveryPrice) {
+    private final DeliveryPriceRepository deliveryPriceRepository;
+
+    @Transactional(readOnly = true)
+    public OrderPrice calculatePrices(List<OrderProduct> orderProducts) {
         Money totalProductPrice = orderProducts.stream()
                 .map(OrderProduct::getTotalPrice)
                 .reduce(Money.zero(), Money::plus);
@@ -20,6 +26,9 @@ public class PricingService {
         Money packagingPrice = orderProducts.stream()
                 .map(OrderProduct::getPackagingPrice)
                 .reduce(Money.zero(), Money::plus);
+
+        DeliveryPrice deliveryPricePolicy = deliveryPriceRepository.getDefaultDeliveryPrice();
+        Money deliveryPrice = deliveryPricePolicy.calculateDeliveryPrice(totalProductPrice);
 
         return OrderPrice.create(totalProductPrice, packagingPrice, deliveryPrice);
     }

--- a/src/main/java/shop/sajotuna/order/orders/service/dto/command/CreateOrderCommand.java
+++ b/src/main/java/shop/sajotuna/order/orders/service/dto/command/CreateOrderCommand.java
@@ -14,7 +14,6 @@ import java.util.List;
 public class CreateOrderCommand {
     private final Orderer orderer;
     private final ShippingInfo shippingInfo;
-    private final Money deliveryPrice;
     private final PaymentMethod paymentMethod;
     private final Long orderCouponId;
     private final Money usedPoint;


### PR DESCRIPTION
## 변경 사항
- 배송비 정책 도메인, 서비스 구현
- 하나의 배송비 정책만 존재한다고 가정
- 관리자의 수정, 조회를 위해 테이블로 설계
- 주문 시 주문 금액에 따른 배송비 책정

## 관련 이슈

closed #72 
