### PR TITLE
[feat] : 반품 로직 구현

### DIFF
--- a/http/admin/orderStatus.http
+++ b/http/admin/orderStatus.http
@@ -1,0 +1,2 @@
+### 배송중으로 전환
+PUT localhost:10366/api/admin/orders/7/delivery

--- a/http/coupon.http
+++ b/http/coupon.http
@@ -21,3 +21,75 @@ Content-Type: application/json
   "couponId": 5,
   "issuedAt": "20250620151112"
 }
+
+### 쿠폰 상세 조회
+GET localhost:10366/api/coupons/1
+
+### 회원의 쿠폰 목록 조회
+GET localhost:10366/api/coupons/users
+X-User-Id: 1
+
+### 도서별 사용 가능 쿠폰 조회
+GET localhost:10366/api/coupons/available-coupons/book?isbn=9781234567890&price=15000
+X-User-Id: 1
+
+### 주문별 사용 가능 쿠폰 조회
+POST localhost:10366/api/coupons/available-coupons/order
+Content-Type: application/json
+X-User-Id: 1
+
+25000
+
+### 도서별 쿠폰 생성
+POST localhost:10366/api/admin/coupons/book?isbn=9781234567890
+Content-Type: application/json
+
+{
+  "name": "특정 도서 할인 쿠폰",
+  "couponType": "BOOK",
+  "policyType": "FIXED",
+  "discountAmount": 2000,
+  "minOrderAmount": 10000,
+  "maxDiscountAmount": 2000,
+  "validDays": 30
+}
+
+### 카테고리별 쿠폰 생성
+POST localhost:10366/api/admin/coupons/category?categoryId=1
+Content-Type: application/json
+
+{
+  "name": "카테고리 할인 쿠폰",
+  "couponType": "CATEGORY",
+  "policyType": "PERCENTAGE",
+  "discountAmount": 10,
+  "minOrderAmount": 20000,
+  "maxDiscountAmount": 5000,
+  "validDays": 60
+}
+
+### 쿠폰 수정
+PUT localhost:10366/api/admin/coupons/1
+Content-Type: application/json
+
+{
+  "name": "수정된 쿠폰",
+  "couponType": "ORDER",
+  "policyType": "FIXED",
+  "discountAmount": 1500,
+  "minOrderAmount": 15000,
+  "maxDiscountAmount": 1500,
+  "validDays": 90
+}
+
+### 쿠폰 삭제
+DELETE localhost:10366/api/admin/coupons/1
+
+### 웰컴 쿠폰 발급
+POST localhost:10366/api/coupons/users/issue-welcome
+Content-Type: application/json
+
+{
+  "userId": 1,
+  "userEmail": "welcome@example.com"
+}

--- a/http/orderStatus.http
+++ b/http/orderStatus.http
@@ -1,0 +1,17 @@
+### 주문 취소
+PUT localhost:10366/api/orders/1/cancel
+
+### 주문 반품 처리 - 미사용 반품 (10일 이내, 택배비 차감)
+PUT localhost:10366/api/orders/7/return?return-reason=UNUSED
+X-User-Id: 1
+
+### 주문 반품 처리 - 파손 반품 (30일 이내, 택배비 차감 없음)
+PUT localhost:10366/api/orders/1/return?return-reason=DAMAGED
+X-User-Id: 1
+
+### 주문 반품 처리 - 파본 반품 (30일 이내, 택배비 차감 없음)
+PUT localhost:10366/api/orders/1/return?return-reason=DEFECTIVE
+X-User-Id: 1
+
+### 주문 취소 처리
+PUT localhost:10366/api/orders/1/cancel

--- a/http/orders.http
+++ b/http/orders.http
@@ -38,7 +38,22 @@ X-User-Id: 1
   ]
 }
 
-### 비회원 주문
+### 주문 상품 조회
+GET localhost:10366/api/orders/product/1
+
+### 주문 번호에 포함된 상품들 조회
+GET localhost:10366/api/orders/product/list/2
+
+### 주문 목록 조회
+GET localhost:10366/api/admin/orders?page=0&size=5
+
+### 배송 상태에 따라 주문 목록 조회
+GET localhost:10366/api/admin/orders/pending?page=0&size=5
+
+### 게스트 주문 조회
+GET localhost:10366/api/orders/guest/bYY4mqih9Jvs5CH
+
+### 게스트 주문 생성
 POST localhost:10366/api/orders/guest
 Content-Type: application/json
 
@@ -50,73 +65,16 @@ Content-Type: application/json
   "recipientPhoneNumber": "010-9876-5432",
   "recipientEmail": "kim@example.com",
   "recipientAddress": "서울시 강남구 테헤란로 123",
-  "shippingDate": "20250710081219",
+  "expectedDeliveryDate": "20250710081219",
+  "orderCouponId": null,
+  "usedPoint": 0,
   "items": [
     {
       "orderPackagingId": 1,
       "isbn": "test",
-      "qty": 2,
-      "amount": 70000,
-      "packagingRequest": true
-    },
-    {
-      "isbn": "test2",
       "qty": 1,
-      "amount": 5990,
+      "amount": 15000,
       "packagingRequest": false
     }
   ]
-}
-
-### 주문 반품
-PUT localhost:10366/api/orders/returned/2
-Content-Type: application/json
-
-{
-  "userId": 1
-}
-
-### 주문 취소
-PUT localhost:10366/api/orders/cancelled/1
-
-### 주문 상품 조회
-GET localhost:10366/api/orders/product/1
-
-### 주문 번호에 포함된 상품들 조회
-GET localhost:10366/api/orders/product/list/2
-
-
-
-
-### 주문 목록 조회
-GET localhost:10366/api/admin/orders?page=0&size=5
-
-### 배송 상태에 따라 주문 목록 조회
-GET localhost:10366/api/admin/orders/pending?page=0&size=5
-
-### 주문 배송 중으로 전환
-PUT localhost:10366/api/admin/orders/pending/1
-
-
-
-
-### package 목록 조회
-GET localhost:10366/api/orders/package
-
-### package 추가
-POST localhost:10366/api/admin/packages/package
-Content-Type: application/json
-
-{
-  "packaging": "test",
-  "price": 1000
-}
-
-### package 수정
-PUT localhost:10366/api/admin/packages/package/1
-Content-Type: application/json
-
-{
-  "packaging": "change",
-  "price": 5400
 }

--- a/http/package.http
+++ b/http/package.http
@@ -1,0 +1,23 @@
+### package 목록 조회
+GET localhost:10366/api/orders/package
+
+### package 추가
+POST localhost:10366/api/admin/packages/package
+Content-Type: application/json
+
+{
+  "packaging": "test",
+  "price": 1000
+}
+
+### package 수정
+PUT localhost:10366/api/admin/packages/package/1
+Content-Type: application/json
+
+{
+  "packaging": "change",
+  "price": 5400
+}
+
+### package 삭제
+DELETE localhost:10366/api/admin/packages/package/1

--- a/http/stock.http
+++ b/http/stock.http
@@ -1,0 +1,26 @@
+### 상품 재고 생성
+POST localhost:10366/api/stocks
+Content-Type: application/json
+
+{
+  "isbn": "test2",
+  "quantity": 100
+}
+
+### 재고 증가
+PUT localhost:10366/api/stocks/increase
+Content-Type: application/json
+
+{
+  "isbn": "test2",
+  "quantity": 50
+}
+
+### 재고 감소
+PUT localhost:10366/api/stocks/decrease
+Content-Type: application/json
+
+{
+  "isbn": "test2",
+  "quantity": 10
+}

--- a/src/main/java/shop/sajotuna/order/common/advice/ControllerAdvice.java
+++ b/src/main/java/shop/sajotuna/order/common/advice/ControllerAdvice.java
@@ -1,16 +1,19 @@
 package shop.sajotuna.order.common.advice;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import shop.sajotuna.order.common.exception.ApiException;
 
+@Slf4j
 @RestControllerAdvice
 public class ControllerAdvice {
 
     @ExceptionHandler(ApiException.class)
     public ResponseEntity<?> handleApiException(ApiException e) {
+        log.error(e.getMessage(), e);
         return ResponseEntity
                 .status(e.getStatus())
                 .body(e.getMessage());
@@ -18,6 +21,7 @@ public class ControllerAdvice {
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<?> handleValidationException(MethodArgumentNotValidException e) {
+        log.error(e.getMessage(), e);
         return ResponseEntity
                 .badRequest() // 400 Bad Request
                 .body("Validation error: " + e.getBindingResult().getAllErrors().getFirst().getDefaultMessage());
@@ -25,6 +29,7 @@ public class ControllerAdvice {
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<?> handleException(Exception e) {
+        log.error(e.getMessage(), e);
         return ResponseEntity
                 .status(500) // Internal Server Error
                 .body("An unexpected error occurred: " + e.getMessage());

--- a/src/main/java/shop/sajotuna/order/orders/controller/OrderStatusAdminController.java
+++ b/src/main/java/shop/sajotuna/order/orders/controller/OrderStatusAdminController.java
@@ -6,14 +6,14 @@ import org.springframework.web.bind.annotation.*;
 import shop.sajotuna.order.orders.service.OrderStatusService;
 
 @RestController
-@RequestMapping("/api/admin/orders")
+@RequestMapping("/api/admin/orders/{order-id}")
 @RequiredArgsConstructor
 public class OrderStatusAdminController {
 
     private final OrderStatusService orderStatusService;
 
     // 배송 중으로 전환
-    @PutMapping("/pending/{order-id}")
+    @PutMapping("/delivery")
     public ResponseEntity<Void> shippedOrder(@PathVariable("order-id") Long orderId) {
         orderStatusService.shippedOrder(orderId);
 

--- a/src/main/java/shop/sajotuna/order/orders/controller/OrderStatusController.java
+++ b/src/main/java/shop/sajotuna/order/orders/controller/OrderStatusController.java
@@ -3,26 +3,28 @@ package shop.sajotuna.order.orders.controller;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import shop.sajotuna.order.orders.domain.ReturnReason;
 import shop.sajotuna.order.orders.service.OrderStatusService;
 
 @RestController
-@RequestMapping("/api/orders")
+@RequestMapping("/api/orders/{order-id}")
 @RequiredArgsConstructor
 public class OrderStatusController {
 
     private final OrderStatusService orderStatusService;
 
     // 주문 반품 처리
-    @PutMapping("/returned/{order-id}")
-    public ResponseEntity<Void> returnedOrder(@PathVariable("order-id") Long orderId, @RequestHeader("X-User-Id") Long userId){
-        orderStatusService.returnedOrder(userId, orderId);
+    @PutMapping("/return")
+    public ResponseEntity<Void> returnOrder(@PathVariable("order-id") Long orderId, @RequestHeader("X-User-Id") Long userId,
+                                              @RequestParam("return-reason") ReturnReason returnReason) {
+        orderStatusService.returnOrder(userId, orderId, returnReason);
 
         return ResponseEntity.noContent().build();
     }
 
     // 주문 취소 처리
-    @PutMapping("/cancelled/{order-id}")
-    public ResponseEntity<Void> cancelledOrder(@PathVariable("order-id") Long orderId){
+    @PutMapping("/cancel")
+    public ResponseEntity<Void> cancelOrder(@PathVariable("order-id") Long orderId){
         orderStatusService.cancelOrder(orderId);
 
         return ResponseEntity.noContent().build();

--- a/src/main/java/shop/sajotuna/order/orders/domain/Order.java
+++ b/src/main/java/shop/sajotuna/order/orders/domain/Order.java
@@ -6,10 +6,8 @@ import org.apache.commons.lang.RandomStringUtils;
 import shop.sajotuna.order.common.domain.Money;
 import shop.sajotuna.order.common.exception.NullValueException;
 import shop.sajotuna.order.orders.exception.InvalidStatusException;
-import shop.sajotuna.order.orders.exception.TimeOutException;
 
 import java.time.LocalDateTime;
-import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.ArrayList;
 
@@ -101,6 +99,14 @@ public class Order {
         return orderPrice.getTotalProductPrice().minus(discounts.getTotalDiscountAmount());
     }
 
+    public Money getReturnPrice(ReturnReason returnReason) {
+        Money baseReturnPrice = getFinalPrice().minus(orderPrice.getDeliveryPrice());
+        if (returnReason.isDeductShippingFee()) {
+            return baseReturnPrice.minus(orderPrice.getDeliveryPrice());
+        }
+        return baseReturnPrice;
+    }
+
     // 주문 발송
     public void shipped() {
         if (!this.status.equals(OrderStatus.PENDING)) {
@@ -128,13 +134,13 @@ public class Order {
     }
 
     // 주문 반품
-    public void returned() {
+    public void returned(ReturnReason returnReason) {
         if (!this.status.equals(OrderStatus.DELIVERED)) {
             throw new InvalidStatusException();
         }
-        if (ChronoUnit.DAYS.between(shippingInfo.getShippingStartDate(), LocalDateTime.now()) > 10) {
-            throw new TimeOutException();
-        }
+
+        LocalDateTime shippingStartDate = shippingInfo.getShippingStartDate();
+        returnReason.validateReturnPeriod(shippingStartDate);
 
         this.status = OrderStatus.RETURNED;
     }

--- a/src/main/java/shop/sajotuna/order/orders/domain/ReturnReason.java
+++ b/src/main/java/shop/sajotuna/order/orders/domain/ReturnReason.java
@@ -1,0 +1,31 @@
+package shop.sajotuna.order.orders.domain;
+
+import lombok.Getter;
+import shop.sajotuna.order.orders.exception.TimeOutException;
+
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+
+@Getter
+public enum ReturnReason {
+
+    // TODO: 반품 사유 세분화? 일단 임시로 지정
+    UNUSED(10, true),
+    DAMAGED(30, false),
+    DEFECTIVE(30, false);
+
+    private final int maxDays;
+    private final boolean deductShippingFee;
+
+    ReturnReason(int maxDays, boolean deductShippingFee) {
+        this.maxDays = maxDays;
+        this.deductShippingFee = deductShippingFee;
+    }
+
+    public void validateReturnPeriod(LocalDateTime shippingDate) {
+        long daysPassed = ChronoUnit.DAYS.between(shippingDate, LocalDateTime.now());
+        if (daysPassed > maxDays) {
+            throw new TimeOutException();
+        }
+    }
+}

--- a/src/main/java/shop/sajotuna/order/orders/repository/OrderRepository.java
+++ b/src/main/java/shop/sajotuna/order/orders/repository/OrderRepository.java
@@ -4,11 +4,13 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import shop.sajotuna.order.orders.domain.Order;
 import shop.sajotuna.order.orders.domain.OrderStatus;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 
 public interface OrderRepository extends JpaRepository<Order, Long> {
@@ -24,4 +26,7 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
     Order findOrderByOrderNumber(String orderNumber);
 
     List<Order> findByOrdererUserIdAndCreatedAtAfter(Long userId, LocalDateTime createdAt);
+
+    @Query("SELECT o FROM Order o JOIN FETCH o.orderProducts WHERE o.id = :orderId")
+    Optional<Order> findByIdWithOrderProducts(@Param("orderId") Long orderId);
 }

--- a/src/main/java/shop/sajotuna/order/orders/service/OrderStatusService.java
+++ b/src/main/java/shop/sajotuna/order/orders/service/OrderStatusService.java
@@ -5,6 +5,7 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import shop.sajotuna.order.orders.domain.Order;
+import shop.sajotuna.order.orders.domain.ReturnReason;
 import shop.sajotuna.order.orders.repository.OrderRepository;
 import shop.sajotuna.order.payment.domain.Payment;
 import shop.sajotuna.order.payment.repository.PaymentRepository;
@@ -12,6 +13,7 @@ import shop.sajotuna.order.point.domain.PointPolicyType;
 import shop.sajotuna.order.point.exception.OrderNotFoundException;
 import shop.sajotuna.order.point.service.PointQueueService;
 import shop.sajotuna.order.point.service.dto.event.PointEvent;
+import shop.sajotuna.order.stock.service.StockService;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -21,8 +23,8 @@ import java.util.List;
 public class OrderStatusService {
 
     private final OrderRepository orderRepository;
-    private final PaymentRepository paymentRepository;
     private final PointQueueService pointQueueService;
+    private final StockService stockService;
 
     private static final String SCHEDULE = "0 0 12 * * *";
 
@@ -45,13 +47,16 @@ public class OrderStatusService {
 
     // 주문 반품 처리
     @Transactional
-    public void returnedOrder(Long userId, Long orderId) {
-        Order order = orderRepository.findById(orderId).orElseThrow(OrderNotFoundException::new);
-        order.returned();
+    public void returnOrder(Long userId, Long orderId, ReturnReason returnReason) {
+        Order order = orderRepository.findByIdWithOrderProducts(orderId).orElseThrow(OrderNotFoundException::new);
+        order.returned(returnReason);
 
         // 반품시 결제금액은 포인트로 적립됨
-        Payment payment = paymentRepository.getPaymentByOrder_Id(orderId);
-        pointQueueService.sendEarnPointsMessage(new PointEvent(userId, PointPolicyType.RETURNED, payment.getAmount()));
+        order.getOrderProducts().forEach(
+                product -> stockService.increaseStock(product.getIsbn(), product.getQty())
+        );
+
+        pointQueueService.sendEarnPointsMessage(new PointEvent(userId, PointPolicyType.RETURNED, order.getReturnPrice(returnReason)));
     }
 
     // 주문 취소 처리

--- a/src/test/java/shop/sajotuna/order/orders/service/OrderStatusServiceTest.java
+++ b/src/test/java/shop/sajotuna/order/orders/service/OrderStatusServiceTest.java
@@ -1,0 +1,227 @@
+package shop.sajotuna.order.orders.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import shop.sajotuna.order.common.domain.Money;
+import shop.sajotuna.order.orders.domain.*;
+import shop.sajotuna.order.orders.repository.OrderRepository;
+import shop.sajotuna.order.point.domain.PointPolicyType;
+import shop.sajotuna.order.point.exception.OrderNotFoundException;
+import shop.sajotuna.order.point.service.PointQueueService;
+import shop.sajotuna.order.point.service.dto.event.PointEvent;
+import shop.sajotuna.order.stock.service.StockService;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class OrderStatusServiceTest {
+
+    @Mock
+    private OrderRepository orderRepository;
+
+    @Mock
+    private PointQueueService pointQueueService;
+
+    @Mock
+    private StockService stockService;
+
+    @InjectMocks
+    private OrderStatusService orderStatusService;
+
+    @Test
+    @DisplayName("반품 처리 성공 - 미사용 반품 (10일 이내)")
+    void returnedOrder_unused_success() {
+        // given
+        Long userId = 1L;
+        Long orderId = 1L;
+        ReturnReason returnReason = ReturnReason.UNUSED;
+        
+        Order order = createTestOrder();
+        OrderProduct orderProduct = createTestOrderProduct("9781234567890", 2);
+        order.getOrderProducts().add(orderProduct);
+        
+        when(orderRepository.findByIdWithOrderProducts(orderId)).thenReturn(Optional.of(order));
+
+        // when
+        orderStatusService.returnOrder(userId, orderId, returnReason);
+
+        // then
+        assertThat(order.getStatus()).isEqualTo(OrderStatus.RETURNED);
+        verify(stockService).increaseStock("9781234567890", 2);
+        verify(pointQueueService).sendEarnPointsMessage(any(PointEvent.class));
+    }
+
+    @Test
+    @DisplayName("반품 처리 성공 - 파손 반품 (30일 이내)")
+    void returnedOrder_damaged_success() {
+        // given
+        Long userId = 1L;
+        Long orderId = 1L;
+        ReturnReason returnReason = ReturnReason.DAMAGED;
+        
+        Order order = createTestOrder();
+        OrderProduct orderProduct = createTestOrderProduct("9781234567890", 1);
+        order.getOrderProducts().add(orderProduct);
+        
+        when(orderRepository.findByIdWithOrderProducts(orderId)).thenReturn(Optional.of(order));
+
+        // when
+        orderStatusService.returnOrder(userId, orderId, returnReason);
+
+        // then
+        assertThat(order.getStatus()).isEqualTo(OrderStatus.RETURNED);
+        verify(stockService).increaseStock("9781234567890", 1);
+        verify(pointQueueService).sendEarnPointsMessage(any(PointEvent.class));
+    }
+
+    @Test
+    @DisplayName("반품 처리 성공 - 파본 반품 (30일 이내)")
+    void returnedOrder_defective_success() {
+        // given
+        Long userId = 1L;
+        Long orderId = 1L;
+        ReturnReason returnReason = ReturnReason.DEFECTIVE;
+        
+        Order order = createTestOrder();
+        OrderProduct orderProduct = createTestOrderProduct("9781234567890", 1);
+        order.getOrderProducts().add(orderProduct);
+        
+        when(orderRepository.findByIdWithOrderProducts(orderId)).thenReturn(Optional.of(order));
+
+        // when
+        orderStatusService.returnOrder(userId, orderId, returnReason);
+
+        // then
+        assertThat(order.getStatus()).isEqualTo(OrderStatus.RETURNED);
+        verify(stockService).increaseStock("9781234567890", 1);
+        verify(pointQueueService).sendEarnPointsMessage(any(PointEvent.class));
+    }
+
+    @Test
+    @DisplayName("반품 처리 실패 - 주문을 찾을 수 없음")
+    void returnedOrder_orderNotFound() {
+        // given
+        Long userId = 1L;
+        Long orderId = 999L;
+        ReturnReason returnReason = ReturnReason.UNUSED;
+        
+        when(orderRepository.findByIdWithOrderProducts(orderId)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> orderStatusService.returnOrder(userId, orderId, returnReason))
+                .isInstanceOf(OrderNotFoundException.class);
+        
+        verify(stockService, never()).increaseStock(anyString(), anyInt());
+        verify(pointQueueService, never()).sendEarnPointsMessage(any(PointEvent.class));
+    }
+
+    @Test
+    @DisplayName("반품 처리 - 여러 상품 재고 복원")
+    void returnedOrder_multipleProducts() {
+        // given
+        Long userId = 1L;
+        Long orderId = 1L;
+        ReturnReason returnReason = ReturnReason.UNUSED;
+        
+        Order order = createTestOrder();
+        OrderProduct product1 = createTestOrderProduct("9781234567890", 2);
+        OrderProduct product2 = createTestOrderProduct("9781234567891", 1);
+        order.getOrderProducts().addAll(List.of(product1, product2));
+        
+        when(orderRepository.findByIdWithOrderProducts(orderId)).thenReturn(Optional.of(order));
+
+        // when
+        orderStatusService.returnOrder(userId, orderId, returnReason);
+
+        // then
+        assertThat(order.getStatus()).isEqualTo(OrderStatus.RETURNED);
+        verify(stockService).increaseStock("9781234567890", 2);
+        verify(stockService).increaseStock("9781234567891", 1);
+        verify(pointQueueService).sendEarnPointsMessage(any(PointEvent.class));
+    }
+
+    @Test
+    @DisplayName("반품 금액 계산 - 미사용 반품시 택배비 차감")
+    void returnedOrder_unused_deductShippingFee() {
+        // given
+        Long userId = 1L;
+        Long orderId = 1L;
+        ReturnReason returnReason = ReturnReason.UNUSED;
+        
+        Order order = createTestOrder();
+        OrderProduct orderProduct = createTestOrderProduct("9781234567890", 1);
+        order.getOrderProducts().add(orderProduct);
+        
+        when(orderRepository.findByIdWithOrderProducts(orderId)).thenReturn(Optional.of(order));
+
+        // when
+        orderStatusService.returnOrder(userId, orderId, returnReason);
+
+        // then
+        verify(pointQueueService).sendEarnPointsMessage(argThat(pointEvent -> 
+            pointEvent.getUserId().equals(userId) &&
+            pointEvent.getType().equals(PointPolicyType.RETURNED) &&
+            pointEvent.getTotalPrice().equals(order.getReturnPrice(returnReason))
+        ));
+    }
+
+    @Test
+    @DisplayName("반품 금액 계산 - 파손/파본 반품시 택배비 차감 없음")
+    void returnedOrder_damaged_noDeductShippingFee() {
+        // given
+        Long userId = 1L;
+        Long orderId = 1L;
+        ReturnReason returnReason = ReturnReason.DAMAGED;
+        
+        Order order = createTestOrder();
+        OrderProduct orderProduct = createTestOrderProduct("9781234567890", 1);
+        order.getOrderProducts().add(orderProduct);
+        
+        when(orderRepository.findByIdWithOrderProducts(orderId)).thenReturn(Optional.of(order));
+
+        // when
+        orderStatusService.returnOrder(userId, orderId, returnReason);
+
+        // then
+        verify(pointQueueService).sendEarnPointsMessage(argThat(pointEvent -> 
+            pointEvent.getUserId().equals(userId) &&
+            pointEvent.getType().equals(PointPolicyType.RETURNED) &&
+            pointEvent.getTotalPrice().equals(order.getReturnPrice(returnReason))
+        ));
+    }
+
+    private Order createTestOrder() {
+        Orderer orderer = new Orderer(1L, "홍길동", "010-1234-5678", "test@example.com");
+        ShippingInfo shippingInfo = ShippingInfo.create(
+            "홍길동", "010-1234-5678", "test@example.com",
+            "서울시 강남구 테헤란로 123",
+            LocalDateTime.now().plusDays(3)
+        );
+        OrderPrice orderPrice = OrderPrice.create(Money.of(17000), Money.of(0), Money.of(3000));
+        Discounts discounts = new Discounts(Money.of(0), Money.of(0));
+        
+        Order order = Order.createOrder(orderer, shippingInfo, orderPrice, discounts, List.of());
+        order.shipped();
+        order.delivered();
+        
+        return order;
+    }
+
+    private OrderProduct createTestOrderProduct(String isbn, int quantity) {
+        return OrderProduct.builder()
+            .isbn(isbn)
+            .qty(quantity)
+            .amount(Money.of(10000))
+            .packagingRequest(false)
+            .build();
+    }
+}


### PR DESCRIPTION
## 변경 사항
  반품 정책
  - 미사용 반품: 출고일로부터 10일 이내, 반품택배비 차감
  - 파손/파본 반품: 출고일로부터 30일 이내, 택배비 차감 없음
  - 반품 시 자동 재고 복원 및 포인트 적립

  API
  PUT /api/orders/{order-id}/return?return-reason=UNUSED
  PUT /api/orders/{order-id}/return?return-reason=DAMAGED
  PUT /api/orders/{order-id}/return?return-reason=DEFECTIVE

  테스트
  - 단위 테스트: 7개 테스트 케이스로 모든 반품 시나리오 검증
  - HTTP 테스트: 모든 Controller 엔드포인트
## 관련 이슈

closed #84 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 주문 반품 사유(미사용, 파손, 불량)에 따라 반품 가능 기간 및 배송비 차감 여부를 적용하는 기능이 추가되었습니다.
  * 관리자용 주문 상태(배송중) 변경, 주문/반품/취소 관련 다양한 API 엔드포인트가 추가 및 개선되었습니다.
  * 쿠폰 관련 상세 조회, 발급, 관리 등 다양한 API가 추가되었습니다.
  * 패키지 및 재고 관리 API가 추가되었습니다.

* **버그 수정**
  * 주문 관련 API의 필드명 및 예시가 개선되고, 불필요한 엔드포인트가 정리되었습니다.

* **테스트**
  * 주문 반품 처리 로직에 대한 단위 테스트가 추가되어 다양한 반품 시나리오와 예외 상황을 검증합니다.

* **문서화**
  * 신규 및 개선된 API 엔드포인트 예시가 문서에 반영되었습니다.

* **리팩토링**
  * 주문 상태 및 반품 처리 컨트롤러의 URL 구조와 메서드 시그니처가 개선되었습니다.
  * 예외 발생 시 에러 로그가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->