### PR TITLE
feat: 재고 차감 Atomic Update 및 회원 등급 롤링 윈도우 적용

### DIFF
--- a/src/main/java/shop/sajotuna/order/coupon/repository/BookCouponRepository.java
+++ b/src/main/java/shop/sajotuna/order/coupon/repository/BookCouponRepository.java
@@ -1,11 +1,12 @@
 package shop.sajotuna.order.coupon.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import shop.sajotuna.order.coupon.domain.Coupon;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import shop.sajotuna.order.coupon.domain.CouponSpecificBook;
 
 import java.util.List;
-import java.util.Optional;
+import java.util.Set;
 
 public interface BookCouponRepository extends JpaRepository<CouponSpecificBook, Long> {
     boolean existsByCoupon_Id(Long couponId);
@@ -16,4 +17,14 @@ public interface BookCouponRepository extends JpaRepository<CouponSpecificBook, 
 
     List<CouponSpecificBook> findByIsbn(String isbn);
 
+    @Query("""
+            SELECT b.coupon.id
+            FROM CouponSpecificBook b
+            WHERE b.coupon.id IN :couponIds
+              AND b.isbn = :isbn
+            """)
+    Set<Long> findCouponIdsByCouponIdInAndIsbn(
+            @Param("couponIds") Set<Long> couponIds,
+            @Param("isbn") String isbn
+    );
 }

--- a/src/main/java/shop/sajotuna/order/coupon/repository/CategoryCouponRepository.java
+++ b/src/main/java/shop/sajotuna/order/coupon/repository/CategoryCouponRepository.java
@@ -1,6 +1,8 @@
 package shop.sajotuna.order.coupon.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import shop.sajotuna.order.coupon.domain.CouponSpecificCategory;
 
 import java.util.List;
@@ -14,4 +16,15 @@ public interface CategoryCouponRepository extends JpaRepository<CouponSpecificCa
     boolean existsByCouponIdAndCategoryIdIn(Long couponId, Set<Long> categoryIds);
 
     List<CouponSpecificCategory> findByCategoryIdIn(Set<Long> categoryIds);
+
+    @Query("""
+            SELECT c.coupon.id
+            FROM CouponSpecificCategory c
+            WHERE c.coupon.id IN :couponIds
+              AND c.categoryId IN :categoryIds
+            """)
+    Set<Long> findCouponIdsByCouponIdInAndCategoryIdIn(
+            @Param("couponIds") Set<Long> couponIds,
+            @Param("categoryIds") Set<Long> categoryIds
+    );
 }

--- a/src/main/java/shop/sajotuna/order/coupon/repository/UserCouponRepository.java
+++ b/src/main/java/shop/sajotuna/order/coupon/repository/UserCouponRepository.java
@@ -12,7 +12,7 @@ import java.util.Optional;
 
 public interface UserCouponRepository extends JpaRepository<UserCoupon, Long> {
 
-    @EntityGraph(value = "coupon")
+    @EntityGraph(attributePaths = {"coupon"})
     List<UserCoupon> findByUserId(Long userId);
 
     @EntityGraph(attributePaths = {"coupon"})

--- a/src/main/java/shop/sajotuna/order/coupon/service/UserCouponService.java
+++ b/src/main/java/shop/sajotuna/order/coupon/service/UserCouponService.java
@@ -21,7 +21,7 @@ import shop.sajotuna.order.coupon.repository.CouponRepository;
 import shop.sajotuna.order.coupon.exception.CouponNotFoundException;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -94,17 +94,28 @@ public class UserCouponService {
         List<UserCoupon> availableCoupons = userCoupons.stream().filter(coupon -> coupon.getType() == UserCouponType.AVAILABLE).toList();
 
         Set<Coupon> coupons = availableCoupons.stream().map(UserCoupon::getCoupon).collect(Collectors.toSet());
-        List<CouponResponse> result = new ArrayList<>();
-        for (Coupon coupon : coupons) {
-
-            if (bookCouponRepository.existsByCouponIdAndIsbn(coupon.getId(), bookInfo.getIsbn())) {
-                result.add(CouponResponse.from(coupon));
-            }
-            if (bookInfo.getCategoryIds() != null && categoryCouponRepository.existsByCouponIdAndCategoryIdIn(coupon.getId(), bookInfo.getCategoryIds())) {
-                result.add(CouponResponse.from(coupon));
-            }
+        if (coupons.isEmpty()) {
+            return List.of();
         }
-        return result;
+
+        Set<Long> couponIds = coupons.stream()
+                .map(Coupon::getId)
+                .collect(Collectors.toSet());
+        Set<Long> matchedCouponIds = new HashSet<>(
+                bookCouponRepository.findCouponIdsByCouponIdInAndIsbn(couponIds, bookInfo.getIsbn())
+        );
+
+        if (bookInfo.getCategoryIds() != null && !bookInfo.getCategoryIds().isEmpty()) {
+            matchedCouponIds.addAll(categoryCouponRepository.findCouponIdsByCouponIdInAndCategoryIdIn(
+                    couponIds,
+                    bookInfo.getCategoryIds()
+            ));
+        }
+
+        return coupons.stream()
+                .filter(coupon -> matchedCouponIds.contains(coupon.getId()))
+                .map(CouponResponse::from)
+                .toList();
     }
 
     // 사용 가능한 오더 쿠폰 조회

--- a/src/main/java/shop/sajotuna/order/orders/domain/Order.java
+++ b/src/main/java/shop/sajotuna/order/orders/domain/Order.java
@@ -17,7 +17,13 @@ import java.util.ArrayList;
 @Builder(access = AccessLevel.PRIVATE)
 @Getter
 @Entity
-@Table(name = "orders")
+@Table(
+        name = "orders",
+        indexes = {
+                @Index(name = "idx_orders_created_user_status", columnList = "created_at, user_id, status"),
+                @Index(name = "idx_orders_user_created_status", columnList = "user_id, created_at, status")
+        }
+)
 public class Order {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/shop/sajotuna/order/orders/repository/OrderRepository.java
+++ b/src/main/java/shop/sajotuna/order/orders/repository/OrderRepository.java
@@ -59,6 +59,9 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
             @Param("statuses") List<OrderStatus> statuses
     );
 
-    @Query("SELECT o FROM Order o JOIN FETCH o.orderProducts WHERE o.id = :orderId")
+    @Query("SELECT DISTINCT o FROM Order o LEFT JOIN FETCH o.orderProducts WHERE o.id = :orderId")
     Optional<Order> findByIdWithOrderProducts(@Param("orderId") Long orderId);
+
+    @Query("SELECT DISTINCT o FROM Order o LEFT JOIN FETCH o.orderProducts WHERE o.orderNumber = :orderNumber")
+    Optional<Order> findByOrderNumberWithOrderProducts(@Param("orderNumber") String orderNumber);
 }

--- a/src/main/java/shop/sajotuna/order/orders/repository/OrderRepository.java
+++ b/src/main/java/shop/sajotuna/order/orders/repository/OrderRepository.java
@@ -45,6 +45,20 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
             @Param("statuses") List<OrderStatus> statuses
     );
 
+    @Query("""
+            SELECT DISTINCT o.orderer.userId
+            FROM Order o
+            WHERE o.orderer.userId IS NOT NULL
+              AND o.createdAt >= :from
+              AND o.createdAt < :to
+              AND o.status IN :statuses
+            """)
+    List<Long> findUserIdsWithOrdersExpiringFromGradeWindow(
+            @Param("from") LocalDateTime from,
+            @Param("to") LocalDateTime to,
+            @Param("statuses") List<OrderStatus> statuses
+    );
+
     @Query("SELECT o FROM Order o JOIN FETCH o.orderProducts WHERE o.id = :orderId")
     Optional<Order> findByIdWithOrderProducts(@Param("orderId") Long orderId);
 }

--- a/src/main/java/shop/sajotuna/order/orders/repository/OrderRepository.java
+++ b/src/main/java/shop/sajotuna/order/orders/repository/OrderRepository.java
@@ -28,6 +28,23 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
 
     List<Order> findByOrdererUserIdAndCreatedAtAfter(Long userId, LocalDateTime createdAt);
 
+    @Query("""
+            SELECT COALESCE(SUM(
+                o.orderPrice.totalProductPrice.amount
+                - o.discounts.couponDiscountAmount.amount
+                - o.discounts.usedPoint.amount
+            ), 0)
+            FROM Order o
+            WHERE o.orderer.userId = :userId
+              AND o.createdAt >= :createdAt
+              AND o.status IN :statuses
+            """)
+    Long sumRecentOrderAmount(
+            @Param("userId") Long userId,
+            @Param("createdAt") LocalDateTime createdAt,
+            @Param("statuses") List<OrderStatus> statuses
+    );
+
     @Query("SELECT o FROM Order o JOIN FETCH o.orderProducts WHERE o.id = :orderId")
     Optional<Order> findByIdWithOrderProducts(@Param("orderId") Long orderId);
 }

--- a/src/main/java/shop/sajotuna/order/orders/service/OrderFormService.java
+++ b/src/main/java/shop/sajotuna/order/orders/service/OrderFormService.java
@@ -32,7 +32,7 @@ public class OrderFormService {
 
         if (userId == null) {
             return OrderFormResponse.builder()
-                    .packages(packageService.getPackages())
+                    .packages(packages)
                     .deliveryPrice(DeliveryPriceResponse.of(deliveryPrice))
                     .build();
         }

--- a/src/main/java/shop/sajotuna/order/orders/service/OrderQueryService.java
+++ b/src/main/java/shop/sajotuna/order/orders/service/OrderQueryService.java
@@ -9,7 +9,6 @@ import org.springframework.transaction.annotation.Transactional;
 import shop.sajotuna.order.orders.controller.dto.response.*;
 import shop.sajotuna.order.orders.domain.*;
 import shop.sajotuna.order.orders.repository.*;
-import shop.sajotuna.order.orders.service.product.OrderProductService;
 import shop.sajotuna.order.payment.domain.Payment;
 import shop.sajotuna.order.payment.repository.PaymentRepository;
 import shop.sajotuna.order.point.exception.OrderNotFoundException;
@@ -22,7 +21,6 @@ import java.util.List;
 public class OrderQueryService {
     private final OrderRepository orderRepository;
     private final PaymentRepository paymentRepository;
-    private final OrderProductService orderProductService;
 
     public OrderInfoResponse getOrderInfo(String orderNumber){
         Order order = orderRepository.findOrderByOrderNumber(orderNumber);
@@ -35,9 +33,11 @@ public class OrderQueryService {
 
     // 주문 조회
     public OrderDetailResponse findOrderDetail(long orderId){
-        Order order = orderRepository.findById(orderId).orElseThrow(OrderNotFoundException::new);
+        Order order = orderRepository.findByIdWithOrderProducts(orderId).orElseThrow(OrderNotFoundException::new);
 
-        List<OrderProductResponse> orderProducts = orderProductService.findByOrderId(orderId);
+        List<OrderProductResponse> orderProducts = order.getOrderProducts().stream()
+                .map(OrderProductResponse::from)
+                .toList();
 
         Payment payment = paymentRepository.getPaymentByOrder_Id(orderId);
 
@@ -46,12 +46,12 @@ public class OrderQueryService {
 
     // 비회원 주문 조회
     public OrderDetailResponse findOrderDetailByOrderNumber(String orderNumber){
-        Order order = orderRepository.findOrderByOrderNumber(orderNumber);
-        if(order == null){
-            throw new OrderNotFoundException();
-        }
+        Order order = orderRepository.findByOrderNumberWithOrderProducts(orderNumber)
+                .orElseThrow(OrderNotFoundException::new);
 
-        List<OrderProductResponse> orderProducts = orderProductService.findByOrderId(order.getId());
+        List<OrderProductResponse> orderProducts = order.getOrderProducts().stream()
+                .map(OrderProductResponse::from)
+                .toList();
         Payment payment = paymentRepository.getPaymentByOrder_Id(order.getId());
 
         return OrderDetailResponse.from(order, orderProducts, payment);

--- a/src/main/java/shop/sajotuna/order/orders/service/OrderStatusService.java
+++ b/src/main/java/shop/sajotuna/order/orders/service/OrderStatusService.java
@@ -5,6 +5,7 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import shop.sajotuna.order.orders.domain.Order;
+import shop.sajotuna.order.orders.domain.OrderStatus;
 import shop.sajotuna.order.orders.domain.ReturnReason;
 import shop.sajotuna.order.orders.repository.OrderRepository;
 import shop.sajotuna.order.payment.service.PaymentService;
@@ -13,6 +14,7 @@ import shop.sajotuna.order.point.exception.InvalidUserIdException;
 import shop.sajotuna.order.point.exception.OrderNotFoundException;
 import shop.sajotuna.order.point.service.PointService;
 import shop.sajotuna.order.point.service.dto.event.PointEarnRequest;
+import shop.sajotuna.order.point.service.dto.event.UserGradeRefreshEvent;
 
 import java.util.Objects;
 
@@ -52,6 +54,7 @@ public class OrderStatusService {
                         order.getReturnPrice(returnReason)
                 )
         );
+        publishUserGradeRefreshEvent(userId);
     }
 
     // 주문 취소 처리
@@ -81,18 +84,19 @@ public class OrderStatusService {
 
         // 결제 취소 요청
         paymentService.cancelPayment(orderId, "cancel");
+        publishUserGradeRefreshEvent(userId);
     }
 
     public void cancelOrderBeforePayment(Long userId, Long orderId) {
         Order order = orderRepository.findById(orderId).orElseThrow(OrderNotFoundException::new);
-        order.cancelPayment();
-
         refundAndCleanup(order, userId);
     }
 
     public void refundAndCleanup(Order order, Long userId) {
         refundService.returnStock(order);
-        order.cancelPayment();
+        if (order.getStatus() == OrderStatus.BEFORE_PAYMENT) {
+            order.cancelPayment();
+        }
 
         if (userId == null) {
             orderRepository.delete(order);
@@ -110,5 +114,12 @@ public class OrderStatusService {
                         order.getDiscounts().getUsedPoint()
                 )
         );
+        publishUserGradeRefreshEvent(userId);
+    }
+
+    private void publishUserGradeRefreshEvent(Long userId) {
+        if (userId != null) {
+            eventPublisher.publishEvent(new UserGradeRefreshEvent(userId));
+        }
     }
 }

--- a/src/main/java/shop/sajotuna/order/orders/service/pricing/OrderTotalPriceService.java
+++ b/src/main/java/shop/sajotuna/order/orders/service/pricing/OrderTotalPriceService.java
@@ -4,7 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import shop.sajotuna.order.common.domain.Money;
-import shop.sajotuna.order.orders.domain.Order;
+import shop.sajotuna.order.orders.domain.OrderStatus;
 import shop.sajotuna.order.orders.repository.OrderRepository;
 
 import java.time.LocalDateTime;
@@ -16,13 +16,14 @@ public class OrderTotalPriceService {
 
     private final OrderRepository orderRepository;
 
-    // 3개월 간 순수 주문 금액 계산
     @Transactional(readOnly = true)
     public Money calculateTotalOrderAmount(Long userId) {
         LocalDateTime threeMonthsAgo = LocalDateTime.now().minusMonths(3);
-        List<Order> orders = orderRepository.findByOrdererUserIdAndCreatedAtAfter(userId, threeMonthsAgo);
-        return orders.stream()
-                .map(Order::getFinalProductPrice)
-                .reduce(Money.zero(), Money::plus);
+        Long totalAmount = orderRepository.sumRecentOrderAmount(
+                userId,
+                threeMonthsAgo,
+                List.of(OrderStatus.PENDING, OrderStatus.SHIPPED, OrderStatus.DELIVERED)
+        );
+        return Money.of(totalAmount.intValue());
     }
 }

--- a/src/main/java/shop/sajotuna/order/orders/service/pricing/OrderTotalPriceService.java
+++ b/src/main/java/shop/sajotuna/order/orders/service/pricing/OrderTotalPriceService.java
@@ -24,6 +24,6 @@ public class OrderTotalPriceService {
                 threeMonthsAgo,
                 List.of(OrderStatus.PENDING, OrderStatus.SHIPPED, OrderStatus.DELIVERED)
         );
-        return Money.of(totalAmount.intValue());
+        return Money.of(Math.toIntExact(totalAmount));
     }
 }

--- a/src/main/java/shop/sajotuna/order/payment/service/PaymentService.java
+++ b/src/main/java/shop/sajotuna/order/payment/service/PaymentService.java
@@ -44,11 +44,12 @@ public class PaymentService {
         ExternalPaymentService service = externalPaymentServiceFactory.getService(paymentConfirmRequest.getPaymentMethod());
 
         Order order = orderRepository.findOrderByOrderNumber(paymentConfirmRequest.getOrderNumber());
+        PaymentResponse paymentResponse = service.requestPaymentConfirm(paymentConfirmRequest);
+
         order.completePayment();
-        order.getFinalPrice();
         publishUserGradeRefreshEvent(order);
 
-        return service.requestPaymentConfirm(paymentConfirmRequest);
+        return paymentResponse;
     }
 
     // 결제 취소 요청

--- a/src/main/java/shop/sajotuna/order/payment/service/PaymentService.java
+++ b/src/main/java/shop/sajotuna/order/payment/service/PaymentService.java
@@ -2,6 +2,7 @@ package shop.sajotuna.order.payment.service;
 
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import shop.sajotuna.order.orders.domain.Order;
@@ -11,6 +12,7 @@ import shop.sajotuna.order.payment.dto.PaymentResponse;
 import shop.sajotuna.order.payment.domain.Payment;
 import shop.sajotuna.order.payment.exception.PaymentNotFoundException;
 import shop.sajotuna.order.payment.repository.PaymentRepository;
+import shop.sajotuna.order.point.service.dto.event.UserGradeRefreshEvent;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -22,6 +24,7 @@ public class PaymentService {
     private final PaymentRepository paymentRepository;
     private final ExternalPaymentServiceFactory externalPaymentServiceFactory;
     private final OrderRepository orderRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
     // 주문 번호에 맞춰 결제 정보 조회
     @Transactional(readOnly = true)
@@ -43,6 +46,7 @@ public class PaymentService {
         Order order = orderRepository.findOrderByOrderNumber(paymentConfirmRequest.getOrderNumber());
         order.completePayment();
         order.getFinalPrice();
+        publishUserGradeRefreshEvent(order);
 
         return service.requestPaymentConfirm(paymentConfirmRequest);
     }
@@ -56,5 +60,12 @@ public class PaymentService {
         ExternalPaymentService service = externalPaymentServiceFactory.getService(payment.getMethod());
 
         service.requestPaymentCancel(payment, cancelReason);
+    }
+
+    private void publishUserGradeRefreshEvent(Order order) {
+        Long userId = order.getOrderer().getUserId();
+        if (userId != null) {
+            eventPublisher.publishEvent(new UserGradeRefreshEvent(userId));
+        }
     }
 }

--- a/src/main/java/shop/sajotuna/order/payment/service/PaymentService.java
+++ b/src/main/java/shop/sajotuna/order/payment/service/PaymentService.java
@@ -6,6 +6,8 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import shop.sajotuna.order.orders.domain.Order;
+import shop.sajotuna.order.orders.domain.OrderStatus;
+import shop.sajotuna.order.orders.exception.InvalidStatusException;
 import shop.sajotuna.order.orders.repository.OrderRepository;
 import shop.sajotuna.order.payment.dto.PaymentConfirmRequest;
 import shop.sajotuna.order.payment.dto.PaymentResponse;
@@ -44,12 +46,20 @@ public class PaymentService {
         ExternalPaymentService service = externalPaymentServiceFactory.getService(paymentConfirmRequest.getPaymentMethod());
 
         Order order = orderRepository.findOrderByOrderNumber(paymentConfirmRequest.getOrderNumber());
+        validateBeforePayment(order);
+
         PaymentResponse paymentResponse = service.requestPaymentConfirm(paymentConfirmRequest);
 
         order.completePayment();
         publishUserGradeRefreshEvent(order);
 
         return paymentResponse;
+    }
+
+    private void validateBeforePayment(Order order) {
+        if (!OrderStatus.BEFORE_PAYMENT.equals(order.getStatus())) {
+            throw new InvalidStatusException();
+        }
     }
 
     // 결제 취소 요청

--- a/src/main/java/shop/sajotuna/order/point/controller/UserGradeController.java
+++ b/src/main/java/shop/sajotuna/order/point/controller/UserGradeController.java
@@ -16,12 +16,9 @@ public class UserGradeController {
 
     private final UserGradeService userGradeService;
 
-    /**
-     * 등급 조회 시 없으면 새로 삽입. 조회 시 등급 업데이트도 동시에 진행
-     */
     @GetMapping("/{user-id}")
-    public ResponseEntity<GradePointPolicyResponse> getUserGradeAndUpdate(@PathVariable(name = "user-id") Long userId) {
-        GradePointPolicyResponse gradePointPolicyResponse = userGradeService.findAndUpdateGrade(userId);
+    public ResponseEntity<GradePointPolicyResponse> getUserGrade(@PathVariable(name = "user-id") Long userId) {
+        GradePointPolicyResponse gradePointPolicyResponse = userGradeService.getUserGrade(userId);
         return ResponseEntity.ok(gradePointPolicyResponse);
     }
 }

--- a/src/main/java/shop/sajotuna/order/point/service/UserGradeEventListener.java
+++ b/src/main/java/shop/sajotuna/order/point/service/UserGradeEventListener.java
@@ -1,0 +1,22 @@
+package shop.sajotuna.order.point.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+import shop.sajotuna.order.point.service.dto.event.UserGradeRefreshEvent;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class UserGradeEventListener {
+
+    private final UserGradeService userGradeService;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleUserGradeRefreshEvent(UserGradeRefreshEvent event) {
+        log.info("Handling user grade refresh event after transaction commit: {}", event);
+        userGradeService.updateGrade(event.getUserId());
+    }
+}

--- a/src/main/java/shop/sajotuna/order/point/service/UserGradeRollingWindowBatchService.java
+++ b/src/main/java/shop/sajotuna/order/point/service/UserGradeRollingWindowBatchService.java
@@ -1,0 +1,55 @@
+package shop.sajotuna.order.point.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import shop.sajotuna.order.orders.domain.OrderStatus;
+import shop.sajotuna.order.orders.repository.OrderRepository;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UserGradeRollingWindowBatchService {
+
+    private static final String DAILY_GRADE_REFRESH_CRON = "0 0 3 * * *";
+    private static final List<OrderStatus> GRADE_TARGET_STATUSES = List.of(
+            OrderStatus.PENDING,
+            OrderStatus.SHIPPED,
+            OrderStatus.DELIVERED
+    );
+
+    private final OrderRepository orderRepository;
+    private final UserGradeService userGradeService;
+
+    @Scheduled(cron = DAILY_GRADE_REFRESH_CRON)
+    public void refreshExpiredWindowUserGrades() {
+        refreshExpiredWindowUserGrades(LocalDate.now());
+    }
+
+    public void refreshExpiredWindowUserGrades(LocalDate today) {
+        LocalDateTime from = today.minusDays(1).minusMonths(3).atStartOfDay();
+        LocalDateTime to = today.minusMonths(3).atStartOfDay();
+
+        List<Long> userIds = orderRepository.findUserIdsWithOrdersExpiringFromGradeWindow(
+                from,
+                to,
+                GRADE_TARGET_STATUSES
+        );
+
+        userIds.forEach(this::updateGradeSafely);
+        log.info("Refreshed user grades for expired rolling window. targetCount={}", userIds.size());
+    }
+
+    private void updateGradeSafely(Long userId) {
+        try {
+            userGradeService.updateGrade(userId);
+        } catch (Exception e) {
+            log.error("Failed to refresh user grade. userId={}", userId, e);
+        }
+    }
+}

--- a/src/main/java/shop/sajotuna/order/point/service/UserGradeRollingWindowBatchService.java
+++ b/src/main/java/shop/sajotuna/order/point/service/UserGradeRollingWindowBatchService.java
@@ -9,6 +9,7 @@ import shop.sajotuna.order.orders.repository.OrderRepository;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.List;
 
 @Slf4j
@@ -17,6 +18,8 @@ import java.util.List;
 public class UserGradeRollingWindowBatchService {
 
     private static final String DAILY_GRADE_REFRESH_CRON = "0 0 3 * * *";
+    private static final String GRADE_REFRESH_ZONE = "Asia/Seoul";
+    private static final ZoneId GRADE_REFRESH_ZONE_ID = ZoneId.of(GRADE_REFRESH_ZONE);
     private static final List<OrderStatus> GRADE_TARGET_STATUSES = List.of(
             OrderStatus.PENDING,
             OrderStatus.SHIPPED,
@@ -26,9 +29,9 @@ public class UserGradeRollingWindowBatchService {
     private final OrderRepository orderRepository;
     private final UserGradeService userGradeService;
 
-    @Scheduled(cron = DAILY_GRADE_REFRESH_CRON)
+    @Scheduled(cron = DAILY_GRADE_REFRESH_CRON, zone = GRADE_REFRESH_ZONE)
     public void refreshExpiredWindowUserGrades() {
-        refreshExpiredWindowUserGrades(LocalDate.now());
+        refreshExpiredWindowUserGrades(LocalDate.now(GRADE_REFRESH_ZONE_ID));
     }
 
     public void refreshExpiredWindowUserGrades(LocalDate today) {

--- a/src/main/java/shop/sajotuna/order/point/service/UserGradeService.java
+++ b/src/main/java/shop/sajotuna/order/point/service/UserGradeService.java
@@ -2,6 +2,7 @@ package shop.sajotuna.order.point.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import shop.sajotuna.order.common.domain.Money;
 import shop.sajotuna.order.orders.service.pricing.OrderTotalPriceService;
 import shop.sajotuna.order.point.controller.response.GradePointPolicyResponse;
@@ -21,18 +22,28 @@ public class UserGradeService {
     private final GradePointPolicyQueryRepository gradePointPolicyQueryRepository;
     private final UserGradeRepository userGradeRepository;
 
-    public GradePointPolicyResponse findAndUpdateGrade(Long userId) {
-        // 회원 등급 정보가 없다면 기본 등급 지정
-        UserGrade userGrade = userGradeRepository.findByUserId(userId)
-                .orElse(UserGrade.createForRegisterUser(userId, gradePointPolicyRepository.findByGrade(Grade.GENERAL)));
+    @Transactional(readOnly = true)
+    public GradePointPolicyResponse getUserGrade(Long userId) {
+        UserGrade userGrade = findOrCreateDefaultGrade(userId);
+        return GradePointPolicyResponse.from(userGrade.getGrade());
+    }
 
+    @Transactional
+    public void updateGrade(Long userId) {
+        UserGrade userGrade = findOrCreateDefaultGrade(userId);
         Money totalOrderAmount = orderTotalPriceService.calculateTotalOrderAmount(userId);
-
-        GradePointPolicy applicablePolicy = gradePointPolicyQueryRepository.findApplicablePolicy(totalOrderAmount.getAmount());
+        GradePointPolicy applicablePolicy =
+                gradePointPolicyQueryRepository.findApplicablePolicy(totalOrderAmount.getAmount());
 
         userGrade.updateGrade(applicablePolicy);
-        UserGrade save = userGradeRepository.save(userGrade);
+        userGradeRepository.save(userGrade);
+    }
 
-        return GradePointPolicyResponse.from(save.getGrade());
+    private UserGrade findOrCreateDefaultGrade(Long userId) {
+        return userGradeRepository.findByUserId(userId)
+                .orElseGet(() -> UserGrade.createForRegisterUser(
+                        userId,
+                        gradePointPolicyRepository.findByGrade(Grade.GENERAL)
+                ));
     }
 }

--- a/src/main/java/shop/sajotuna/order/point/service/dto/event/UserGradeRefreshEvent.java
+++ b/src/main/java/shop/sajotuna/order/point/service/dto/event/UserGradeRefreshEvent.java
@@ -1,0 +1,12 @@
+package shop.sajotuna.order.point.service.dto.event;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@ToString
+@RequiredArgsConstructor
+public class UserGradeRefreshEvent {
+    private final Long userId;
+}

--- a/src/main/java/shop/sajotuna/order/stock/repository/BookStockRepository.java
+++ b/src/main/java/shop/sajotuna/order/stock/repository/BookStockRepository.java
@@ -17,7 +17,8 @@ public interface BookStockRepository extends JpaRepository<BookStock, Long> {
     @Modifying(flushAutomatically = true, clearAutomatically = true)
     @Query("""
             update BookStock bs
-            set bs.stock.quantity = bs.stock.quantity - :quantity
+            set bs.stock.quantity = bs.stock.quantity - :quantity,
+                bs.version = bs.version + 1
             where bs.isbn = :isbn
               and bs.stock.quantity >= :quantity
             """)

--- a/src/main/java/shop/sajotuna/order/stock/repository/BookStockRepository.java
+++ b/src/main/java/shop/sajotuna/order/stock/repository/BookStockRepository.java
@@ -1,6 +1,9 @@
 package shop.sajotuna.order.stock.repository;
 
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import shop.sajotuna.order.stock.domain.BookStock;
 
 import java.util.List;
@@ -10,6 +13,15 @@ public interface BookStockRepository extends JpaRepository<BookStock, Long> {
     Optional<BookStock> findByIsbn(String isbn);
 
     boolean existsByIsbn(String isbn);
+
+    @Modifying(flushAutomatically = true, clearAutomatically = true)
+    @Query("""
+            update BookStock bs
+            set bs.stock.quantity = bs.stock.quantity - :quantity
+            where bs.isbn = :isbn
+              and bs.stock.quantity >= :quantity
+            """)
+    int decreaseStockAtomically(@Param("isbn") String isbn, @Param("quantity") int quantity);
 
     List<BookStock> findByIsbnIn(List<String> isbns);
 }

--- a/src/main/java/shop/sajotuna/order/stock/service/StockService.java
+++ b/src/main/java/shop/sajotuna/order/stock/service/StockService.java
@@ -28,6 +28,10 @@ public class StockService {
     private final BookStockRepository bookStockRepository;
 
     public void decreaseStock(String isbn, int quantity) {
+        if (quantity <= 0) {
+            throw new IllegalArgumentException("Stock decrease quantity must be greater than zero.");
+        }
+
         int affectedRows = bookStockRepository.decreaseStockAtomically(isbn, quantity);
         if (affectedRows == 1) {
             return;

--- a/src/main/java/shop/sajotuna/order/stock/service/StockService.java
+++ b/src/main/java/shop/sajotuna/order/stock/service/StockService.java
@@ -13,6 +13,7 @@ import shop.sajotuna.order.stock.controller.response.BookStockResponse;
 import shop.sajotuna.order.stock.domain.BookStock;
 import shop.sajotuna.order.stock.domain.Stock;
 import shop.sajotuna.order.stock.exception.BookStockNotFoundException;
+import shop.sajotuna.order.stock.exception.InsufficientStockException;
 import shop.sajotuna.order.stock.exception.StockProcessingFailedException;
 import shop.sajotuna.order.stock.repository.BookStockRepository;
 
@@ -26,19 +27,16 @@ public class StockService {
 
     private final BookStockRepository bookStockRepository;
 
-    @Retryable(
-            maxAttempts = 5,
-            backoff = @Backoff(delay = 100, multiplier = 1.5),
-            retryFor = OptimisticLockingFailureException.class
-    )
     public void decreaseStock(String isbn, int quantity) {
-        BookStock bookStock = bookStockRepository.findByIsbn(isbn)
-                .orElseThrow(BookStockNotFoundException::new);
-        bookStock.decreaseStock(Stock.of(quantity));
-
-        if (bookStock.isSoldOut()) {
-            // TODO: Book-API에 품절 상태 업데이트 요청
+        int affectedRows = bookStockRepository.decreaseStockAtomically(isbn, quantity);
+        if (affectedRows == 1) {
+            return;
         }
+
+        if (!bookStockRepository.existsByIsbn(isbn)) {
+            throw new BookStockNotFoundException();
+        }
+        throw new InsufficientStockException();
     }
 
     @Retryable(
@@ -62,14 +60,8 @@ public class StockService {
     }
 
     @Recover
-    public void recoverDecreaseStock(OptimisticLockingFailureException ex, String isbn, int quantity) {
-        log.error("재고 차감 최종 실패 - ISBN: {}, 수량: {}, 재시도 횟수 초과", isbn, quantity, ex);
-        throw new StockProcessingFailedException(isbn, quantity);
-    }
-
-    @Recover
     public void recoverIncreaseStock(OptimisticLockingFailureException ex, String isbn, int quantity) {
-        log.error("재고 증가 최종 실패 - ISBN: {}, 수량: {}, 재시도 횟수 초과", isbn, quantity, ex);
+        log.error("stock increase failed after retry - ISBN: {}, quantity: {}", isbn, quantity, ex);
         throw new StockProcessingFailedException(isbn, quantity);
     }
 
@@ -78,12 +70,10 @@ public class StockService {
                 .map(CreateStockRequest::getIsbn)
                 .toList();
 
-        // 이미 존재하는 ISBN 조회
         List<String> existingIsbns = bookStockRepository.findByIsbnIn(isbns).stream()
                 .map(BookStock::getIsbn)
                 .toList();
 
-        // 중복되지 않은 것만 필터링
         List<BookStock> bookStocks = createStockRequest.stream()
                 .filter(request -> !existingIsbns.contains(request.getIsbn()))
                 .map(request -> new BookStock(request.getIsbn(), Stock.of(request.getStock())))

--- a/src/test/java/shop/sajotuna/order/coupon/service/UserCouponServiceQueryTest.java
+++ b/src/test/java/shop/sajotuna/order/coupon/service/UserCouponServiceQueryTest.java
@@ -1,0 +1,121 @@
+package shop.sajotuna.order.coupon.service;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+import org.hibernate.SessionFactory;
+import org.hibernate.stat.Statistics;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+import shop.sajotuna.order.common.domain.Money;
+import shop.sajotuna.order.coupon.domain.Coupon;
+import shop.sajotuna.order.coupon.domain.CouponPolicyType;
+import shop.sajotuna.order.coupon.domain.CouponSpecificBook;
+import shop.sajotuna.order.coupon.domain.CouponSpecificCategory;
+import shop.sajotuna.order.coupon.domain.CouponType;
+import shop.sajotuna.order.coupon.domain.UserCoupon;
+import shop.sajotuna.order.coupon.dto.request.BookInfo;
+import shop.sajotuna.order.coupon.dto.response.CouponResponse;
+import shop.sajotuna.order.coupon.repository.BookCouponRepository;
+import shop.sajotuna.order.coupon.repository.CategoryCouponRepository;
+import shop.sajotuna.order.coupon.repository.CouponRepository;
+import shop.sajotuna.order.coupon.repository.UserCouponRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+class UserCouponServiceQueryTest {
+
+    private static final Long USER_ID = 1L;
+    private static final String MATCHING_ISBN = "9788966263158";
+
+    @Autowired
+    private UserCouponService userCouponService;
+
+    @Autowired
+    private CouponRepository couponRepository;
+
+    @Autowired
+    private UserCouponRepository userCouponRepository;
+
+    @Autowired
+    private BookCouponRepository bookCouponRepository;
+
+    @Autowired
+    private CategoryCouponRepository categoryCouponRepository;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @Autowired
+    private EntityManagerFactory entityManagerFactory;
+
+    private Statistics statistics;
+
+    @BeforeEach
+    void setUp() {
+        userCouponRepository.deleteAll();
+        bookCouponRepository.deleteAll();
+        categoryCouponRepository.deleteAll();
+        couponRepository.deleteAll();
+
+        statistics = entityManagerFactory.unwrap(SessionFactory.class).getStatistics();
+        statistics.setStatisticsEnabled(true);
+        statistics.clear();
+    }
+
+    @Test
+    @DisplayName("사용 가능한 도서/카테고리 쿠폰 조회는 보유 쿠폰 수와 무관하게 고정 쿼리로 판별한다")
+    void getAvailableCoupons_usesConstantQueryCount() {
+        Coupon bookCoupon = saveCoupon("book coupon", CouponType.BOOK);
+        Coupon categoryCoupon = saveCoupon("category coupon", CouponType.CATEGORY);
+        Coupon unmatchedCoupon1 = saveCoupon("unmatched coupon 1", CouponType.BOOK);
+        Coupon unmatchedCoupon2 = saveCoupon("unmatched coupon 2", CouponType.CATEGORY);
+
+        userCouponRepository.save(new UserCoupon(bookCoupon, USER_ID, LocalDateTime.now(), 30));
+        userCouponRepository.save(new UserCoupon(categoryCoupon, USER_ID, LocalDateTime.now(), 30));
+        userCouponRepository.save(new UserCoupon(unmatchedCoupon1, USER_ID, LocalDateTime.now(), 30));
+        userCouponRepository.save(new UserCoupon(unmatchedCoupon2, USER_ID, LocalDateTime.now(), 30));
+
+        bookCouponRepository.save(new CouponSpecificBook(MATCHING_ISBN, bookCoupon));
+        bookCouponRepository.save(new CouponSpecificBook("9780000000000", unmatchedCoupon1));
+        categoryCouponRepository.save(new CouponSpecificCategory(10L, categoryCoupon));
+        categoryCouponRepository.save(new CouponSpecificCategory(99L, unmatchedCoupon2));
+
+        entityManager.flush();
+        entityManager.clear();
+        statistics.clear();
+
+        List<CouponResponse> result = userCouponService.getAvailableCoupons(
+                USER_ID,
+                new BookInfo(MATCHING_ISBN, Set.of(10L, 20L))
+        );
+
+        assertThat(result)
+                .extracting(CouponResponse::getName)
+                .containsExactlyInAnyOrder("book coupon", "category coupon");
+        assertThat(statistics.getPrepareStatementCount()).isLessThanOrEqualTo(3);
+    }
+
+    private Coupon saveCoupon(String name, CouponType couponType) {
+        return couponRepository.save(Coupon.builder()
+                .name(name)
+                .couponType(couponType)
+                .policyType(CouponPolicyType.FIXED)
+                .discountAmount(1_000)
+                .minOrderAmount(Money.zero())
+                .maxDiscountAmount(Money.of(1_000))
+                .validDays(30)
+                .build());
+    }
+}

--- a/src/test/java/shop/sajotuna/order/coupon/service/UserCouponServiceTest.java
+++ b/src/test/java/shop/sajotuna/order/coupon/service/UserCouponServiceTest.java
@@ -214,11 +214,10 @@ class UserCouponServiceTest {
         when(userCouponRepository.findByUserId(userId))
                 .thenReturn(List.of(userBookCoupon, userCategoryCoupon));
 
-        when(bookCouponRepository.existsByCouponIdAndIsbn(bookCoupon.getId(), isbn)).thenReturn(true);
-        when(bookCouponRepository.existsByCouponIdAndIsbn(categoryCoupon.getId(), isbn)).thenReturn(false);
-
-        when(categoryCouponRepository.existsByCouponIdAndCategoryIdIn(categoryCoupon.getId(), categoryIds)).thenReturn(true);
-        when(categoryCouponRepository.existsByCouponIdAndCategoryIdIn(bookCoupon.getId(), categoryIds)).thenReturn(false);
+        when(bookCouponRepository.findCouponIdsByCouponIdInAndIsbn(Set.of(bookCoupon.getId(), categoryCoupon.getId()), isbn))
+                .thenReturn(Set.of(bookCoupon.getId()));
+        when(categoryCouponRepository.findCouponIdsByCouponIdInAndCategoryIdIn(Set.of(bookCoupon.getId(), categoryCoupon.getId()), categoryIds))
+                .thenReturn(Set.of(categoryCoupon.getId()));
 
 
         // when
@@ -231,11 +230,8 @@ class UserCouponServiceTest {
                 .containsExactlyInAnyOrder("책 전용 쿠폰", "카테고리 쿠폰");
 
         verify(userCouponRepository).findByUserId(userId);
-        verify(bookCouponRepository).existsByCouponIdAndIsbn(bookCoupon.getId(), isbn);
-        verify(bookCouponRepository).existsByCouponIdAndIsbn(categoryCoupon.getId(), isbn);
-
-        verify(categoryCouponRepository).existsByCouponIdAndCategoryIdIn(categoryCoupon.getId(), categoryIds);
-        verify(categoryCouponRepository).existsByCouponIdAndCategoryIdIn(bookCoupon.getId(), categoryIds);
+        verify(bookCouponRepository).findCouponIdsByCouponIdInAndIsbn(Set.of(bookCoupon.getId(), categoryCoupon.getId()), isbn);
+        verify(categoryCouponRepository).findCouponIdsByCouponIdInAndCategoryIdIn(Set.of(bookCoupon.getId(), categoryCoupon.getId()), categoryIds);
     }
 
     @Test

--- a/src/test/java/shop/sajotuna/order/orders/service/OrderQueryServiceTest.java
+++ b/src/test/java/shop/sajotuna/order/orders/service/OrderQueryServiceTest.java
@@ -88,7 +88,7 @@ public class OrderQueryServiceTest {
         Order fakeOrder = createTestOrder();
 
         // when
-        when(orderRepository.findById(1L)).thenReturn(Optional.of(fakeOrder));
+        when(orderRepository.findByIdWithOrderProducts(1L)).thenReturn(Optional.of(fakeOrder));
 
         OrderDetailResponse response = orderQueryService.findOrderDetail(1L);
 
@@ -102,7 +102,7 @@ public class OrderQueryServiceTest {
     @Test
     @DisplayName("주문 조회 - 주문 찾을 수 없음")
     void getOrderInfo_orderNotFound() {
-        lenient().when(orderRepository.findById(anyLong()))
+        lenient().when(orderRepository.findByIdWithOrderProducts(anyLong()))
                 .thenReturn(Optional.empty());
 
         assertThrows(OrderNotFoundException.class,
@@ -117,8 +117,8 @@ public class OrderQueryServiceTest {
         String orderNumber = fakeOrder.getOrderNumber();
 
         // when
-        when(orderRepository.findOrderByOrderNumber(orderNumber))
-                .thenReturn(fakeOrder);
+        when(orderRepository.findByOrderNumberWithOrderProducts(orderNumber))
+                .thenReturn(Optional.of(fakeOrder));
 
         OrderDetailResponse response = orderQueryService.findOrderDetailByOrderNumber(orderNumber);
 
@@ -135,8 +135,8 @@ public class OrderQueryServiceTest {
         String nonExistentOrderNumber = "NON_EXISTENT";
 
         // when
-        when(orderRepository.findOrderByOrderNumber(nonExistentOrderNumber))
-                .thenReturn(null);
+        when(orderRepository.findByOrderNumberWithOrderProducts(nonExistentOrderNumber))
+                .thenReturn(Optional.empty());
 
         // then
         assertThrows(OrderNotFoundException.class,

--- a/src/test/java/shop/sajotuna/order/orders/service/OrderStatusServiceTest.java
+++ b/src/test/java/shop/sajotuna/order/orders/service/OrderStatusServiceTest.java
@@ -184,10 +184,11 @@ class OrderStatusServiceTest {
         orderStatusService.returnOrder(userId, orderId, returnReason);
 
         // then
-        verify(eventPublisher).publishEvent(argThat((PointEarnRequest pointEvent) -> 
-            pointEvent.getUserId().equals(userId) &&
-            pointEvent.getType().equals(PointPolicyType.RETURNED) &&
-            pointEvent.getPointAmount().equals(order.getReturnPrice(returnReason))
+        verify(eventPublisher).publishEvent((Object) argThat(event ->
+            event instanceof PointEarnRequest pointEvent &&
+                    pointEvent.getUserId().equals(userId) &&
+                    pointEvent.getType().equals(PointPolicyType.RETURNED) &&
+                    pointEvent.getPointAmount().equals(order.getReturnPrice(returnReason))
         ));
     }
 
@@ -209,10 +210,11 @@ class OrderStatusServiceTest {
         orderStatusService.returnOrder(userId, orderId, returnReason);
 
         // then
-        verify(eventPublisher).publishEvent(argThat((PointEarnRequest pointEvent) -> 
-            pointEvent.getUserId().equals(userId) &&
-            pointEvent.getType().equals(PointPolicyType.RETURNED) &&
-            pointEvent.getPointAmount().equals(order.getReturnPrice(returnReason))
+        verify(eventPublisher).publishEvent((Object) argThat(event ->
+            event instanceof PointEarnRequest pointEvent &&
+                    pointEvent.getUserId().equals(userId) &&
+                    pointEvent.getType().equals(PointPolicyType.RETURNED) &&
+                    pointEvent.getPointAmount().equals(order.getReturnPrice(returnReason))
         ));
     }
 

--- a/src/test/java/shop/sajotuna/order/orders/service/pricing/OrderTotalPriceServiceIntegrationTest.java
+++ b/src/test/java/shop/sajotuna/order/orders/service/pricing/OrderTotalPriceServiceIntegrationTest.java
@@ -5,15 +5,18 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.util.ReflectionTestUtils;
 import shop.sajotuna.order.common.domain.Money;
 import shop.sajotuna.order.orders.domain.Discounts;
 import shop.sajotuna.order.orders.domain.Order;
 import shop.sajotuna.order.orders.domain.OrderPrice;
 import shop.sajotuna.order.orders.domain.Orderer;
+import shop.sajotuna.order.orders.domain.OrderStatus;
 import shop.sajotuna.order.orders.domain.ShippingInfo;
 import shop.sajotuna.order.orders.repository.OrderRepository;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -47,14 +50,57 @@ class OrderTotalPriceServiceIntegrationTest {
         assertThat(result).isEqualTo(Money.of(28_500));
     }
 
+    @Test
+    void findUserIdsWithOrdersExpiringFromGradeWindow_returnsOnlyUsersInExpiredWindow() {
+        Order expiredActiveOrder = paidOrder(Money.of(10_000), Money.zero(), Money.zero());
+        ReflectionTestUtils.setField(expiredActiveOrder, "createdAt", LocalDateTime.of(2026, 2, 11, 10, 0));
+
+        Order duplicatedExpiredActiveOrder = paidOrder(Money.of(20_000), Money.zero(), Money.zero());
+        ReflectionTestUtils.setField(duplicatedExpiredActiveOrder, "createdAt", LocalDateTime.of(2026, 2, 11, 12, 0));
+
+        Order stillIncludedOrder = paidOrder(2L, Money.of(30_000), Money.zero(), Money.zero());
+        ReflectionTestUtils.setField(stillIncludedOrder, "createdAt", LocalDateTime.of(2026, 2, 12, 0, 0));
+
+        Order expiredCancelledOrder = cancelledOrder(3L, Money.of(40_000));
+        ReflectionTestUtils.setField(expiredCancelledOrder, "createdAt", LocalDateTime.of(2026, 2, 11, 10, 0));
+
+        Order expiredGuestOrder = paidGuestOrder(Money.of(50_000));
+        ReflectionTestUtils.setField(expiredGuestOrder, "createdAt", LocalDateTime.of(2026, 2, 11, 10, 0));
+
+        orderRepository.saveAll(List.of(
+                expiredActiveOrder,
+                duplicatedExpiredActiveOrder,
+                stillIncludedOrder,
+                expiredCancelledOrder,
+                expiredGuestOrder
+        ));
+
+        List<Long> userIds = orderRepository.findUserIdsWithOrdersExpiringFromGradeWindow(
+                LocalDateTime.of(2026, 2, 11, 0, 0),
+                LocalDateTime.of(2026, 2, 12, 0, 0),
+                List.of(OrderStatus.PENDING, OrderStatus.SHIPPED, OrderStatus.DELIVERED)
+        );
+
+        assertThat(userIds).containsExactly(USER_ID);
+    }
+
     private Order paidOrder(Money totalProductPrice, Money couponDiscountAmount, Money usedPoint) {
+        return paidOrder(USER_ID, totalProductPrice, couponDiscountAmount, usedPoint);
+    }
+
+    private Order paidOrder(Long userId, Money totalProductPrice, Money couponDiscountAmount, Money usedPoint) {
         Order order = createOrder(totalProductPrice, couponDiscountAmount, usedPoint);
+        ReflectionTestUtils.setField(order, "orderer", new Orderer(userId, "tester", "010-1234-5678", "tester@example.com"));
         order.completePayment();
         return order;
     }
 
     private Order cancelledOrder(Money totalProductPrice) {
-        Order order = paidOrder(totalProductPrice, Money.zero(), Money.zero());
+        return cancelledOrder(USER_ID, totalProductPrice);
+    }
+
+    private Order cancelledOrder(Long userId, Money totalProductPrice) {
+        Order order = paidOrder(userId, totalProductPrice, Money.zero(), Money.zero());
         order.cancelled();
         return order;
     }
@@ -77,5 +123,23 @@ class OrderTotalPriceServiceIntegrationTest {
                 new Discounts(couponDiscountAmount, usedPoint, null),
                 List.of()
         );
+    }
+
+    private Order paidGuestOrder(Money totalProductPrice) {
+        Order order = Order.createOrder(
+                new Orderer(null, "guest", "010-1234-5678", "guest@example.com"),
+                ShippingInfo.create(
+                        "guest",
+                        "010-1234-5678",
+                        "guest@example.com",
+                        "Seoul",
+                        LocalDate.now().plusDays(3)
+                ),
+                OrderPrice.create(totalProductPrice, Money.zero(), Money.zero()),
+                new Discounts(Money.zero(), Money.zero(), null),
+                List.of()
+        );
+        order.completePayment();
+        return order;
     }
 }

--- a/src/test/java/shop/sajotuna/order/orders/service/pricing/OrderTotalPriceServiceIntegrationTest.java
+++ b/src/test/java/shop/sajotuna/order/orders/service/pricing/OrderTotalPriceServiceIntegrationTest.java
@@ -1,0 +1,81 @@
+package shop.sajotuna.order.orders.service.pricing;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import shop.sajotuna.order.common.domain.Money;
+import shop.sajotuna.order.orders.domain.Discounts;
+import shop.sajotuna.order.orders.domain.Order;
+import shop.sajotuna.order.orders.domain.OrderPrice;
+import shop.sajotuna.order.orders.domain.Orderer;
+import shop.sajotuna.order.orders.domain.ShippingInfo;
+import shop.sajotuna.order.orders.repository.OrderRepository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class OrderTotalPriceServiceIntegrationTest {
+
+    private static final Long USER_ID = 1L;
+
+    @Autowired
+    private OrderTotalPriceService orderTotalPriceService;
+
+    @Autowired
+    private OrderRepository orderRepository;
+
+    @BeforeEach
+    void setUp() {
+        orderRepository.deleteAll();
+    }
+
+    @Test
+    void calculateTotalOrderAmount_sumsOnlyPaidActiveOrders() {
+        orderRepository.save(paidOrder(Money.of(10_000), Money.of(1_000), Money.of(500)));
+        orderRepository.save(paidOrder(Money.of(20_000), Money.zero(), Money.zero()));
+        orderRepository.save(cancelledOrder(Money.of(50_000)));
+        orderRepository.save(beforePaymentOrder(Money.of(70_000)));
+
+        Money result = orderTotalPriceService.calculateTotalOrderAmount(USER_ID);
+
+        assertThat(result).isEqualTo(Money.of(28_500));
+    }
+
+    private Order paidOrder(Money totalProductPrice, Money couponDiscountAmount, Money usedPoint) {
+        Order order = createOrder(totalProductPrice, couponDiscountAmount, usedPoint);
+        order.completePayment();
+        return order;
+    }
+
+    private Order cancelledOrder(Money totalProductPrice) {
+        Order order = paidOrder(totalProductPrice, Money.zero(), Money.zero());
+        order.cancelled();
+        return order;
+    }
+
+    private Order beforePaymentOrder(Money totalProductPrice) {
+        return createOrder(totalProductPrice, Money.zero(), Money.zero());
+    }
+
+    private Order createOrder(Money totalProductPrice, Money couponDiscountAmount, Money usedPoint) {
+        return Order.createOrder(
+                new Orderer(USER_ID, "tester", "010-1234-5678", "tester@example.com"),
+                ShippingInfo.create(
+                        "tester",
+                        "010-1234-5678",
+                        "tester@example.com",
+                        "Seoul",
+                        LocalDate.now().plusDays(3)
+                ),
+                OrderPrice.create(totalProductPrice, Money.zero(), Money.zero()),
+                new Discounts(couponDiscountAmount, usedPoint, null),
+                List.of()
+        );
+    }
+}

--- a/src/test/java/shop/sajotuna/order/orders/service/pricing/OrderTotalPriceServiceTest.java
+++ b/src/test/java/shop/sajotuna/order/orders/service/pricing/OrderTotalPriceServiceTest.java
@@ -7,15 +7,17 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import shop.sajotuna.order.common.domain.Money;
-import shop.sajotuna.order.orders.domain.Order;
+import shop.sajotuna.order.orders.domain.OrderStatus;
 import shop.sajotuna.order.orders.repository.OrderRepository;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class OrderTotalPriceServiceTest {
@@ -27,66 +29,39 @@ class OrderTotalPriceServiceTest {
     private OrderTotalPriceService orderTotalPriceService;
 
     @Test
-    @DisplayName("3개월간 총 주문 금액 계산 성공 - 주문이 있는 경우")
-    void calculateTotalOrderAmount_withOrders() {
-        // given
+    @DisplayName("recent order amount is calculated by DB SUM query")
+    void calculateTotalOrderAmount_withSumQuery() {
         Long userId = 1L;
-        
-        Order order1 = mock(Order.class);
-        Order order2 = mock(Order.class);
-        Order order3 = mock(Order.class);
-        
-        when(order1.getFinalProductPrice()).thenReturn(Money.of(10000));
-        when(order2.getFinalProductPrice()).thenReturn(Money.of(15000));
-        when(order3.getFinalProductPrice()).thenReturn(Money.of(20000));
-        
-        List<Order> orders = List.of(order1, order2, order3);
-        
-        when(orderRepository.findByOrdererUserIdAndCreatedAtAfter(eq(userId), any(LocalDateTime.class)))
-                .thenReturn(orders);
 
-        // when
+        when(orderRepository.sumRecentOrderAmount(
+                eq(userId),
+                any(LocalDateTime.class),
+                eq(List.of(OrderStatus.PENDING, OrderStatus.SHIPPED, OrderStatus.DELIVERED))
+        )).thenReturn(45_000L);
+
         Money result = orderTotalPriceService.calculateTotalOrderAmount(userId);
 
-        // then
-        assertThat(result).isEqualTo(Money.of(45000));
-        verify(orderRepository).findByOrdererUserIdAndCreatedAtAfter(eq(userId), any(LocalDateTime.class));
+        assertThat(result).isEqualTo(Money.of(45_000));
+        verify(orderRepository).sumRecentOrderAmount(
+                eq(userId),
+                any(LocalDateTime.class),
+                eq(List.of(OrderStatus.PENDING, OrderStatus.SHIPPED, OrderStatus.DELIVERED))
+        );
     }
 
     @Test
-    @DisplayName("3개월간 총 주문 금액 계산 성공 - 주문이 없는 경우")
+    @DisplayName("recent order amount returns zero when there is no order")
     void calculateTotalOrderAmount_noOrders() {
-        // given
         Long userId = 1L;
-        
-        when(orderRepository.findByOrdererUserIdAndCreatedAtAfter(eq(userId), any(LocalDateTime.class)))
-                .thenReturn(List.of());
 
-        // when
+        when(orderRepository.sumRecentOrderAmount(
+                eq(userId),
+                any(LocalDateTime.class),
+                eq(List.of(OrderStatus.PENDING, OrderStatus.SHIPPED, OrderStatus.DELIVERED))
+        )).thenReturn(0L);
+
         Money result = orderTotalPriceService.calculateTotalOrderAmount(userId);
 
-        // then
         assertThat(result).isEqualTo(Money.zero());
-        verify(orderRepository).findByOrdererUserIdAndCreatedAtAfter(eq(userId), any(LocalDateTime.class));
-    }
-
-    @Test
-    @DisplayName("3개월간 총 주문 금액 계산 성공 - 단일 주문")
-    void calculateTotalOrderAmount_singleOrder() {
-        // given
-        Long userId = 1L;
-        
-        Order order = mock(Order.class);
-        when(order.getFinalProductPrice()).thenReturn(Money.of(30000));
-        
-        when(orderRepository.findByOrdererUserIdAndCreatedAtAfter(eq(userId), any(LocalDateTime.class)))
-                .thenReturn(List.of(order));
-
-        // when
-        Money result = orderTotalPriceService.calculateTotalOrderAmount(userId);
-
-        // then
-        assertThat(result).isEqualTo(Money.of(30000));
-        verify(orderRepository).findByOrdererUserIdAndCreatedAtAfter(eq(userId), any(LocalDateTime.class));
     }
 }

--- a/src/test/java/shop/sajotuna/order/orders/service/process/OrderProcessAtomicRollbackTest.java
+++ b/src/test/java/shop/sajotuna/order/orders/service/process/OrderProcessAtomicRollbackTest.java
@@ -1,0 +1,107 @@
+package shop.sajotuna.order.orders.service.process;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import shop.sajotuna.order.common.domain.Money;
+import shop.sajotuna.order.orders.domain.DeliveryPrice;
+import shop.sajotuna.order.orders.domain.Orderer;
+import shop.sajotuna.order.orders.domain.ShippingInfo;
+import shop.sajotuna.order.orders.repository.DeliveryPriceRepository;
+import shop.sajotuna.order.orders.repository.OrderProductRepository;
+import shop.sajotuna.order.orders.repository.OrderRepository;
+import shop.sajotuna.order.orders.service.dto.command.CreateOrderCommand;
+import shop.sajotuna.order.orders.service.dto.command.CreateOrderProductCommand;
+import shop.sajotuna.order.stock.domain.BookStock;
+import shop.sajotuna.order.stock.domain.Stock;
+import shop.sajotuna.order.stock.exception.InsufficientStockException;
+import shop.sajotuna.order.stock.repository.BookStockRepository;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class OrderProcessAtomicRollbackTest {
+
+    private static final String FIRST_ISBN = "ROLLBACK-ISBN-0001";
+    private static final String SECOND_ISBN = "ROLLBACK-ISBN-0002";
+
+    @Autowired
+    private OrderProcessService orderProcessService;
+
+    @Autowired
+    private BookStockRepository bookStockRepository;
+
+    @Autowired
+    private DeliveryPriceRepository deliveryPriceRepository;
+
+    @Autowired
+    private OrderRepository orderRepository;
+
+    @Autowired
+    private OrderProductRepository orderProductRepository;
+
+    @MockitoBean
+    private RabbitTemplate rabbitTemplate;
+
+    @BeforeEach
+    void setUp() {
+        orderProductRepository.deleteAll();
+        orderRepository.deleteAll();
+        bookStockRepository.deleteAll();
+        deliveryPriceRepository.deleteAll();
+
+        deliveryPriceRepository.save(new DeliveryPrice(null, Money.of(30_000), Money.of(3_000)));
+        bookStockRepository.save(new BookStock(FIRST_ISBN, Stock.of(1)));
+        bookStockRepository.save(new BookStock(SECOND_ISBN, Stock.of(0)));
+    }
+
+    @Test
+    void processOrder_rollsBackAlreadyDeductedStockWhenLaterItemIsInsufficient() {
+        CreateOrderCommand command = CreateOrderCommand.builder()
+                .orderer(Orderer.createOrderer(null, "tester", "010-1234-5678", "tester@example.com"))
+                .shippingInfo(ShippingInfo.create(
+                        "tester",
+                        "010-1234-5678",
+                        "tester@example.com",
+                        "Seoul",
+                        LocalDate.now().plusDays(3)
+                ))
+                .usedPoint(Money.zero())
+                .items(List.of(
+                        orderItem(FIRST_ISBN),
+                        orderItem(SECOND_ISBN)
+                ))
+                .build();
+
+        assertThatThrownBy(() -> orderProcessService.processOrder(command))
+                .isInstanceOf(InsufficientStockException.class);
+
+        BookStock firstStock = bookStockRepository.findByIsbn(FIRST_ISBN).orElseThrow();
+        BookStock secondStock = bookStockRepository.findByIsbn(SECOND_ISBN).orElseThrow();
+
+        assertThat(firstStock.getStock().getQuantity()).isEqualTo(1);
+        assertThat(secondStock.getStock().getQuantity()).isZero();
+        assertThat(orderRepository.count()).isZero();
+        assertThat(orderProductRepository.count()).isZero();
+    }
+
+    private CreateOrderProductCommand orderItem(String isbn) {
+        return CreateOrderProductCommand.builder()
+                .isbn(isbn)
+                .quantity(1)
+                .amount(Money.of(15_000))
+                .packagingRequest(false)
+                .categoryIds(Set.of())
+                .build();
+    }
+}

--- a/src/test/java/shop/sajotuna/order/payment/service/PaymentServiceTest.java
+++ b/src/test/java/shop/sajotuna/order/payment/service/PaymentServiceTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
+import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -18,6 +19,7 @@ import shop.sajotuna.order.payment.domain.Payment;
 import shop.sajotuna.order.payment.domain.PaymentMethod;
 import shop.sajotuna.order.payment.dto.PaymentConfirmRequest;
 import shop.sajotuna.order.payment.dto.PaymentResponse;
+import shop.sajotuna.order.payment.exception.PaymentFailException;
 import shop.sajotuna.order.payment.repository.PaymentRepository;
 import shop.sajotuna.order.point.service.dto.event.UserGradeRefreshEvent;
 
@@ -26,6 +28,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
@@ -126,9 +129,29 @@ public class PaymentServiceTest {
 
         // then
         assertEquals(expectedResponse, actualResponse);
-        verify(order).completePayment();
-        verify(cardPaymentService).requestPaymentConfirm(request);
-        verify(eventPublisher).publishEvent(any(UserGradeRefreshEvent.class));
+        InOrder inOrder = inOrder(cardPaymentService, order, eventPublisher);
+        inOrder.verify(cardPaymentService).requestPaymentConfirm(request);
+        inOrder.verify(order).completePayment();
+        inOrder.verify(eventPublisher).publishEvent(any(UserGradeRefreshEvent.class));
+    }
+
+    @Test
+    @DisplayName("결제 승인 실패 시 주문 완료와 등급 갱신 이벤트를 실행하지 않는다")
+    void processUserPayment_paymentConfirmFailed_doesNotCompleteOrder() {
+        Order order = Mockito.mock(Order.class);
+        PaymentConfirmRequest request = new PaymentConfirmRequest(
+                PaymentMethod.CARD, "testtest", 10000, UUID.randomUUID().toString()
+        );
+
+        when(externalPaymentServiceFactory.getService(PaymentMethod.CARD)).thenReturn(cardPaymentService);
+        when(orderRepository.findOrderByOrderNumber("testtest")).thenReturn(order);
+        when(cardPaymentService.requestPaymentConfirm(request)).thenThrow(new PaymentFailException());
+
+        assertThatThrownBy(() -> paymentService.processUserPayment(request))
+                .isInstanceOf(PaymentFailException.class);
+
+        verify(order, never()).completePayment();
+        verify(eventPublisher, never()).publishEvent(any(UserGradeRefreshEvent.class));
     }
 
     @Test

--- a/src/test/java/shop/sajotuna/order/payment/service/PaymentServiceTest.java
+++ b/src/test/java/shop/sajotuna/order/payment/service/PaymentServiceTest.java
@@ -14,6 +14,7 @@ import shop.sajotuna.order.common.domain.Money;
 import shop.sajotuna.order.orders.domain.Order;
 import shop.sajotuna.order.orders.domain.Orderer;
 import shop.sajotuna.order.orders.domain.OrderStatus;
+import shop.sajotuna.order.orders.exception.InvalidStatusException;
 import shop.sajotuna.order.orders.repository.OrderRepository;
 import shop.sajotuna.order.payment.domain.Payment;
 import shop.sajotuna.order.payment.domain.PaymentMethod;
@@ -129,7 +130,8 @@ public class PaymentServiceTest {
 
         // then
         assertEquals(expectedResponse, actualResponse);
-        InOrder inOrder = inOrder(cardPaymentService, order, eventPublisher);
+        InOrder inOrder = inOrder(order, cardPaymentService, eventPublisher);
+        inOrder.verify(order).getStatus();
         inOrder.verify(cardPaymentService).requestPaymentConfirm(request);
         inOrder.verify(order).completePayment();
         inOrder.verify(eventPublisher).publishEvent(any(UserGradeRefreshEvent.class));
@@ -145,11 +147,32 @@ public class PaymentServiceTest {
 
         when(externalPaymentServiceFactory.getService(PaymentMethod.CARD)).thenReturn(cardPaymentService);
         when(orderRepository.findOrderByOrderNumber("testtest")).thenReturn(order);
+        when(order.getStatus()).thenReturn(OrderStatus.BEFORE_PAYMENT);
         when(cardPaymentService.requestPaymentConfirm(request)).thenThrow(new PaymentFailException());
 
         assertThatThrownBy(() -> paymentService.processUserPayment(request))
                 .isInstanceOf(PaymentFailException.class);
 
+        verify(order, never()).completePayment();
+        verify(eventPublisher, never()).publishEvent(any(UserGradeRefreshEvent.class));
+    }
+
+    @Test
+    @DisplayName("결제 전 상태가 아니면 외부 결제 승인 요청을 보내지 않는다")
+    void processUserPayment_invalidOrderStatus_doesNotConfirmPayment() {
+        Order order = Mockito.mock(Order.class);
+        PaymentConfirmRequest request = new PaymentConfirmRequest(
+                PaymentMethod.CARD, "testtest", 10000, UUID.randomUUID().toString()
+        );
+
+        when(externalPaymentServiceFactory.getService(PaymentMethod.CARD)).thenReturn(cardPaymentService);
+        when(orderRepository.findOrderByOrderNumber("testtest")).thenReturn(order);
+        when(order.getStatus()).thenReturn(OrderStatus.CANCELLED);
+
+        assertThatThrownBy(() -> paymentService.processUserPayment(request))
+                .isInstanceOf(InvalidStatusException.class);
+
+        verify(cardPaymentService, never()).requestPaymentConfirm(request);
         verify(order, never()).completePayment();
         verify(eventPublisher, never()).publishEvent(any(UserGradeRefreshEvent.class));
     }

--- a/src/test/java/shop/sajotuna/order/payment/service/PaymentServiceTest.java
+++ b/src/test/java/shop/sajotuna/order/payment/service/PaymentServiceTest.java
@@ -8,8 +8,10 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 import shop.sajotuna.order.common.domain.Money;
 import shop.sajotuna.order.orders.domain.Order;
+import shop.sajotuna.order.orders.domain.Orderer;
 import shop.sajotuna.order.orders.domain.OrderStatus;
 import shop.sajotuna.order.orders.repository.OrderRepository;
 import shop.sajotuna.order.payment.domain.Payment;
@@ -17,6 +19,7 @@ import shop.sajotuna.order.payment.domain.PaymentMethod;
 import shop.sajotuna.order.payment.dto.PaymentConfirmRequest;
 import shop.sajotuna.order.payment.dto.PaymentResponse;
 import shop.sajotuna.order.payment.repository.PaymentRepository;
+import shop.sajotuna.order.point.service.dto.event.UserGradeRefreshEvent;
 
 import java.util.List;
 import java.util.Optional;
@@ -46,9 +49,12 @@ public class PaymentServiceTest {
     @Mock
     private ExternalPaymentServiceFactory externalPaymentServiceFactory;
 
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
+
     @BeforeEach
     void setup() {
-        paymentService = new PaymentService(paymentRepository, externalPaymentServiceFactory, orderRepository);
+        paymentService = new PaymentService(paymentRepository, externalPaymentServiceFactory, orderRepository, eventPublisher);
     }
 
     @Test
@@ -103,6 +109,7 @@ public class PaymentServiceTest {
         lenient().when(order.getOrderNumber()).thenReturn("testtest");
         lenient().when(order.getStatus()).thenReturn(OrderStatus.BEFORE_PAYMENT);
         lenient().when(order.getFinalPrice()).thenReturn(Money.of(10000));
+        lenient().when(order.getOrderer()).thenReturn(new Orderer(1L, "tester", "010-1234-5678", "test@example.com"));
 
         when(externalPaymentServiceFactory.getService(PaymentMethod.CARD)).thenReturn(cardPaymentService);
         when(orderRepository.findOrderByOrderNumber("testtest")).thenReturn(order);
@@ -121,6 +128,7 @@ public class PaymentServiceTest {
         assertEquals(expectedResponse, actualResponse);
         verify(order).completePayment();
         verify(cardPaymentService).requestPaymentConfirm(request);
+        verify(eventPublisher).publishEvent(any(UserGradeRefreshEvent.class));
     }
 
     @Test

--- a/src/test/java/shop/sajotuna/order/point/controller/UserGradeControllerTest.java
+++ b/src/test/java/shop/sajotuna/order/point/controller/UserGradeControllerTest.java
@@ -38,7 +38,7 @@ class UserGradeControllerTest {
                 5
         );
 
-        given(userGradeService.findAndUpdateGrade(userId)).willReturn(response);
+        given(userGradeService.getUserGrade(userId)).willReturn(response);
 
         mockMvc.perform(get("/api/grade/{user-id}", userId))
                 .andExpect(status().isOk())
@@ -48,7 +48,7 @@ class UserGradeControllerTest {
                 .andExpect(jsonPath("$.maxTotalOrderPrice").value(10000))
                 .andExpect(jsonPath("$.pointRate").value(5));
 
-        verify(userGradeService).findAndUpdateGrade(userId);
+        verify(userGradeService).getUserGrade(userId);
     }
 
     @Test
@@ -59,7 +59,7 @@ class UserGradeControllerTest {
         mockMvc.perform(get("/api/grade/{user-id}", invalidUserId))
                 .andExpect(status().isOk());
 
-        verify(userGradeService).findAndUpdateGrade(invalidUserId);
+        verify(userGradeService).getUserGrade(invalidUserId);
     }
 
     @Test
@@ -73,13 +73,13 @@ class UserGradeControllerTest {
                 5
         );
 
-        given(userGradeService.findAndUpdateGrade(nonExistentUserId)).willReturn(response);
+        given(userGradeService.getUserGrade(nonExistentUserId)).willReturn(response);
 
         mockMvc.perform(get("/api/grade/{user-id}", nonExistentUserId))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.grade").value("GENERAL"));
 
-        verify(userGradeService).findAndUpdateGrade(nonExistentUserId);
+        verify(userGradeService).getUserGrade(nonExistentUserId);
     }
 }

--- a/src/test/java/shop/sajotuna/order/point/service/UserGradeEventListenerTest.java
+++ b/src/test/java/shop/sajotuna/order/point/service/UserGradeEventListenerTest.java
@@ -1,0 +1,21 @@
+package shop.sajotuna.order.point.service;
+
+import org.junit.jupiter.api.Test;
+import shop.sajotuna.order.point.service.dto.event.UserGradeRefreshEvent;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+class UserGradeEventListenerTest {
+
+    @Test
+    void handleUserGradeRefreshEvent_updatesUserGrade() {
+        UserGradeService userGradeService = mock(UserGradeService.class);
+        UserGradeEventListener listener = new UserGradeEventListener(userGradeService);
+        UserGradeRefreshEvent event = new UserGradeRefreshEvent(1L);
+
+        listener.handleUserGradeRefreshEvent(event);
+
+        verify(userGradeService).updateGrade(1L);
+    }
+}

--- a/src/test/java/shop/sajotuna/order/point/service/UserGradeRollingWindowBatchServiceTest.java
+++ b/src/test/java/shop/sajotuna/order/point/service/UserGradeRollingWindowBatchServiceTest.java
@@ -1,0 +1,58 @@
+package shop.sajotuna.order.point.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import shop.sajotuna.order.orders.domain.OrderStatus;
+import shop.sajotuna.order.orders.repository.OrderRepository;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class UserGradeRollingWindowBatchServiceTest {
+
+    private final OrderRepository orderRepository = mock(OrderRepository.class);
+    private final UserGradeService userGradeService = mock(UserGradeService.class);
+    private final UserGradeRollingWindowBatchService batchService =
+            new UserGradeRollingWindowBatchService(orderRepository, userGradeService);
+
+    @Test
+    @DisplayName("rolling window에서 제외되는 주문이 있는 회원만 등급을 재계산한다")
+    void refreshExpiredWindowUserGrades_updatesOnlyExpiredWindowUsers() {
+        LocalDate today = LocalDate.of(2026, 5, 12);
+        LocalDateTime from = LocalDateTime.of(2026, 2, 11, 0, 0);
+        LocalDateTime to = LocalDateTime.of(2026, 2, 12, 0, 0);
+        List<OrderStatus> statuses = List.of(OrderStatus.PENDING, OrderStatus.SHIPPED, OrderStatus.DELIVERED);
+
+        when(orderRepository.findUserIdsWithOrdersExpiringFromGradeWindow(from, to, statuses))
+                .thenReturn(List.of(1L, 2L));
+
+        batchService.refreshExpiredWindowUserGrades(today);
+
+        verify(userGradeService).updateGrade(1L);
+        verify(userGradeService).updateGrade(2L);
+    }
+
+    @Test
+    @DisplayName("일부 회원 등급 갱신 실패 시 나머지 회원 갱신은 계속한다")
+    void refreshExpiredWindowUserGrades_continuesAfterSingleUserFailure() {
+        LocalDate today = LocalDate.of(2026, 5, 12);
+        LocalDateTime from = LocalDateTime.of(2026, 2, 11, 0, 0);
+        LocalDateTime to = LocalDateTime.of(2026, 2, 12, 0, 0);
+        List<OrderStatus> statuses = List.of(OrderStatus.PENDING, OrderStatus.SHIPPED, OrderStatus.DELIVERED);
+
+        when(orderRepository.findUserIdsWithOrdersExpiringFromGradeWindow(from, to, statuses))
+                .thenReturn(List.of(1L, 2L));
+        doThrow(new RuntimeException("temporary failure")).when(userGradeService).updateGrade(1L);
+
+        batchService.refreshExpiredWindowUserGrades(today);
+
+        verify(userGradeService).updateGrade(1L);
+        verify(userGradeService).updateGrade(2L);
+    }
+}

--- a/src/test/java/shop/sajotuna/order/point/service/UserGradeServiceTest.java
+++ b/src/test/java/shop/sajotuna/order/point/service/UserGradeServiceTest.java
@@ -18,8 +18,11 @@ import shop.sajotuna.order.point.repository.UserGradeRepository;
 
 import java.util.Optional;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class UserGradeServiceTest {
@@ -40,155 +43,89 @@ class UserGradeServiceTest {
 
     @BeforeEach
     void setUp() {
-        userGradeService = new UserGradeService(gradePointPolicyRepository, orderTotalPriceService, gradePointPolicyQueryRepository, userGradeRepository);
+        userGradeService = new UserGradeService(
+                gradePointPolicyRepository,
+                orderTotalPriceService,
+                gradePointPolicyQueryRepository,
+                userGradeRepository
+        );
     }
 
     @Test
-    @DisplayName("findAndUpdateGrade - 기존 사용자 등급 업데이트 성공")
-    void findAndUpdateGrade_existingUser_success() {
-        // given
+    @DisplayName("getUserGrade returns stored grade without recalculation")
+    void getUserGrade_existingUser_success() {
         Long userId = 1L;
-        Money totalOrderAmount = Money.of(100000);
-        
-        GradePointPolicy generalPolicy = new GradePointPolicy(1L, Grade.GENERAL, Money.of(0), Money.of(100000), 1);
-        GradePointPolicy royalPolicy = new GradePointPolicy(2L, Grade.ROYAL, Money.of(100000), Money.of(200000), 2);
-        
-        UserGrade existingUserGrade = UserGrade.builder()
-                .id(1L)
-                .userId(userId)
-                .grade(generalPolicy)
-                .build();
-        
-        UserGrade updatedUserGrade = UserGrade.builder()
+        GradePointPolicy royalPolicy = new GradePointPolicy(2L, Grade.ROYAL, Money.of(100_000), Money.of(200_000), 2);
+        UserGrade userGrade = UserGrade.builder()
                 .id(1L)
                 .userId(userId)
                 .grade(royalPolicy)
                 .build();
 
-        when(userGradeRepository.findByUserId(userId)).thenReturn(Optional.of(existingUserGrade));
-        when(orderTotalPriceService.calculateTotalOrderAmount(userId)).thenReturn(totalOrderAmount);
-        when(gradePointPolicyQueryRepository.findApplicablePolicy(totalOrderAmount.getAmount())).thenReturn(royalPolicy);
-        when(userGradeRepository.save(any(UserGrade.class))).thenReturn(updatedUserGrade);
+        when(userGradeRepository.findByUserId(userId)).thenReturn(Optional.of(userGrade));
 
-        // when
-        GradePointPolicyResponse response = userGradeService.findAndUpdateGrade(userId);
+        GradePointPolicyResponse response = userGradeService.getUserGrade(userId);
 
-        // then
-        assertThat(response).isNotNull();
         assertThat(response.getGrade()).isEqualTo(Grade.ROYAL);
         assertThat(response.getPointRate()).isEqualTo(2);
-        assertThat(response.getMinTotalOrderPrice()).isEqualTo(100000);
-        assertThat(response.getMaxTotalOrderPrice()).isEqualTo(200000);
-
-        verify(userGradeRepository).findByUserId(userId);
-        verify(orderTotalPriceService).calculateTotalOrderAmount(userId);
-        verify(gradePointPolicyQueryRepository).findApplicablePolicy(totalOrderAmount.getAmount());
-        verify(userGradeRepository).save(any(UserGrade.class));
+        verify(orderTotalPriceService, never()).calculateTotalOrderAmount(userId);
+        verify(gradePointPolicyQueryRepository, never()).findApplicablePolicy(any(Integer.class));
+        verify(userGradeRepository, never()).save(any(UserGrade.class));
     }
 
     @Test
-    @DisplayName("findAndUpdateGrade - 신규 사용자 기본 등급 설정")
-    void findAndUpdateGrade_newUser_createWithDefaultGrade() {
-        // given
+    @DisplayName("getUserGrade returns default grade when user grade is not stored")
+    void getUserGrade_newUser_defaultGrade() {
         Long userId = 2L;
-        Money totalOrderAmount = Money.of(10000);
-        
-        GradePointPolicy generalPolicy = new GradePointPolicy(1L, Grade.GENERAL, Money.of(0), Money.of(100000), 1);
-        
-        UserGrade newUserGrade = UserGrade.builder()
-                .id(2L)
-                .userId(userId)
-                .grade(generalPolicy)
-                .build();
+        GradePointPolicy generalPolicy = new GradePointPolicy(1L, Grade.GENERAL, Money.of(0), Money.of(100_000), 1);
 
         when(userGradeRepository.findByUserId(userId)).thenReturn(Optional.empty());
         when(gradePointPolicyRepository.findByGrade(Grade.GENERAL)).thenReturn(generalPolicy);
-        when(orderTotalPriceService.calculateTotalOrderAmount(userId)).thenReturn(totalOrderAmount);
-        when(gradePointPolicyQueryRepository.findApplicablePolicy(totalOrderAmount.getAmount())).thenReturn(generalPolicy);
-        when(userGradeRepository.save(any(UserGrade.class))).thenReturn(newUserGrade);
 
-        // when
-        GradePointPolicyResponse response = userGradeService.findAndUpdateGrade(userId);
+        GradePointPolicyResponse response = userGradeService.getUserGrade(userId);
 
-        // then
-        assertThat(response).isNotNull();
         assertThat(response.getGrade()).isEqualTo(Grade.GENERAL);
         assertThat(response.getPointRate()).isEqualTo(1);
-        assertThat(response.getMinTotalOrderPrice()).isEqualTo(0);
-        assertThat(response.getMaxTotalOrderPrice()).isEqualTo(100000);
-
-        verify(userGradeRepository).findByUserId(userId);
-        verify(gradePointPolicyRepository).findByGrade(Grade.GENERAL);
-        verify(orderTotalPriceService).calculateTotalOrderAmount(userId);
-        verify(gradePointPolicyQueryRepository).findApplicablePolicy(totalOrderAmount.getAmount());
-        verify(userGradeRepository).save(any(UserGrade.class));
+        verify(orderTotalPriceService, never()).calculateTotalOrderAmount(userId);
+        verify(userGradeRepository, never()).save(any(UserGrade.class));
     }
 
     @Test
-    @DisplayName("findAndUpdateGrade - 등급 변경 없는 경우")
-    void findAndUpdateGrade_noGradeChange() {
-        // given
-        Long userId = 4L;
-        Money totalOrderAmount = Money.of(30000);
-        
-        GradePointPolicy generalPolicy = new GradePointPolicy(1L, Grade.GENERAL, Money.of(0), Money.of(100000), 1);
-        
-        UserGrade existingUserGrade = UserGrade.builder()
-                .id(4L)
+    @DisplayName("updateGrade recalculates grade from recent order amount")
+    void updateGrade_existingUser_success() {
+        Long userId = 1L;
+        GradePointPolicy generalPolicy = new GradePointPolicy(1L, Grade.GENERAL, Money.of(0), Money.of(100_000), 1);
+        GradePointPolicy royalPolicy = new GradePointPolicy(2L, Grade.ROYAL, Money.of(100_000), Money.of(200_000), 2);
+        UserGrade userGrade = UserGrade.builder()
+                .id(1L)
                 .userId(userId)
                 .grade(generalPolicy)
                 .build();
 
-        when(userGradeRepository.findByUserId(userId)).thenReturn(Optional.of(existingUserGrade));
-        when(orderTotalPriceService.calculateTotalOrderAmount(userId)).thenReturn(totalOrderAmount);
-        when(gradePointPolicyQueryRepository.findApplicablePolicy(totalOrderAmount.getAmount())).thenReturn(generalPolicy);
-        when(userGradeRepository.save(any(UserGrade.class))).thenReturn(existingUserGrade);
+        when(userGradeRepository.findByUserId(userId)).thenReturn(Optional.of(userGrade));
+        when(orderTotalPriceService.calculateTotalOrderAmount(userId)).thenReturn(Money.of(100_000));
+        when(gradePointPolicyQueryRepository.findApplicablePolicy(100_000)).thenReturn(royalPolicy);
 
-        // when
-        GradePointPolicyResponse response = userGradeService.findAndUpdateGrade(userId);
+        userGradeService.updateGrade(userId);
 
-        // then
-        assertThat(response).isNotNull();
-        assertThat(response.getGrade()).isEqualTo(Grade.GENERAL);
-        assertThat(response.getPointRate()).isEqualTo(1);
+        assertThat(userGrade.getGrade()).isEqualTo(royalPolicy);
+        verify(userGradeRepository).save(userGrade);
     }
 
     @Test
-    @DisplayName("findAndUpdateGrade - 최고 등급(PLATINUM) 달성")
-    void findAndUpdateGrade_platinumGrade() {
-        // given
-        Long userId = 5L;
-        Money totalOrderAmount = Money.of(500000);
-        
-        GradePointPolicy royalPolicy = new GradePointPolicy(2L, Grade.ROYAL, Money.of(100000), Money.of(200000), 2);
-        GradePointPolicy platinumPolicy = new GradePointPolicy(4L, Grade.PLATINUM, Money.of(300000), Money.of(Integer.MAX_VALUE), 3);
-        
-        UserGrade existingUserGrade = UserGrade.builder()
-                .id(5L)
-                .userId(userId)
-                .grade(royalPolicy)
-                .build();
-        
-        UserGrade platinumUserGrade = UserGrade.builder()
-                .id(5L)
-                .userId(userId)
-                .grade(platinumPolicy)
-                .build();
+    @DisplayName("updateGrade creates default user grade before recalculation")
+    void updateGrade_newUser_success() {
+        Long userId = 2L;
+        GradePointPolicy generalPolicy = new GradePointPolicy(1L, Grade.GENERAL, Money.of(0), Money.of(100_000), 1);
+        UserGrade newUserGrade = UserGrade.createForRegisterUser(userId, generalPolicy);
 
-        when(userGradeRepository.findByUserId(userId)).thenReturn(Optional.of(existingUserGrade));
-        when(orderTotalPriceService.calculateTotalOrderAmount(userId)).thenReturn(totalOrderAmount);
-        when(gradePointPolicyQueryRepository.findApplicablePolicy(totalOrderAmount.getAmount())).thenReturn(platinumPolicy);
-        when(userGradeRepository.save(any(UserGrade.class))).thenReturn(platinumUserGrade);
+        when(userGradeRepository.findByUserId(userId)).thenReturn(Optional.empty());
+        when(gradePointPolicyRepository.findByGrade(Grade.GENERAL)).thenReturn(generalPolicy);
+        when(orderTotalPriceService.calculateTotalOrderAmount(userId)).thenReturn(Money.zero());
+        when(gradePointPolicyQueryRepository.findApplicablePolicy(0)).thenReturn(generalPolicy);
 
-        // when
-        GradePointPolicyResponse response = userGradeService.findAndUpdateGrade(userId);
+        userGradeService.updateGrade(userId);
 
-        // then
-        assertThat(response).isNotNull();
-        assertThat(response.getGrade()).isEqualTo(Grade.PLATINUM);
-        assertThat(response.getPointRate()).isEqualTo(3);
-        assertThat(response.getMinTotalOrderPrice()).isEqualTo(300000);
-        assertThat(response.getMaxTotalOrderPrice()).isEqualTo(Integer.MAX_VALUE);
+        verify(userGradeRepository).save(any(UserGrade.class));
     }
-
 }

--- a/src/test/java/shop/sajotuna/order/stock/service/StockServiceConcurrencyTest.java
+++ b/src/test/java/shop/sajotuna/order/stock/service/StockServiceConcurrencyTest.java
@@ -129,6 +129,18 @@ public class StockServiceConcurrencyTest {
     }
 
     @Test
+    void decreaseStock_shouldIncrementVersion() {
+        BookStock initialStock = bookStockRepository.findByIsbn(TEST_ISBN).orElseThrow();
+        Long initialVersion = initialStock.getVersion();
+
+        stockService.decreaseStock(TEST_ISBN, 10);
+
+        BookStock finalStock = bookStockRepository.findByIsbn(TEST_ISBN).orElseThrow();
+        assertEquals(INITIAL_STOCK - 10, finalStock.getStock().getQuantity());
+        assertEquals(initialVersion + 1, finalStock.getVersion());
+    }
+
+    @Test
     void stockProcessingFailedException_shouldBeThrownAfterMaxRetries() {
         // 존재하지 않는 ISBN으로 테스트 (재시도 대상이 아님)
         assertThrows(Exception.class, () -> {

--- a/src/test/java/shop/sajotuna/order/stock/service/StockServiceTest.java
+++ b/src/test/java/shop/sajotuna/order/stock/service/StockServiceTest.java
@@ -25,6 +25,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -80,6 +81,24 @@ class StockServiceTest {
 
         verify(bookStockRepository).decreaseStockAtomically(isbn, quantity);
         verify(bookStockRepository).existsByIsbn(isbn);
+    }
+
+    @Test
+    @DisplayName("decrease stock rejects zero quantity before atomic update")
+    void decreaseStock_zeroQuantity() {
+        assertThatThrownBy(() -> stockService.decreaseStock("9781234567890", 0))
+                .isInstanceOf(IllegalArgumentException.class);
+
+        verifyNoInteractions(bookStockRepository);
+    }
+
+    @Test
+    @DisplayName("decrease stock rejects negative quantity before atomic update")
+    void decreaseStock_negativeQuantity() {
+        assertThatThrownBy(() -> stockService.decreaseStock("9781234567890", -1))
+                .isInstanceOf(IllegalArgumentException.class);
+
+        verifyNoInteractions(bookStockRepository);
     }
 
     @Test

--- a/src/test/java/shop/sajotuna/order/stock/service/StockServiceTest.java
+++ b/src/test/java/shop/sajotuna/order/stock/service/StockServiceTest.java
@@ -12,15 +12,20 @@ import shop.sajotuna.order.stock.controller.response.BookStockResponse;
 import shop.sajotuna.order.stock.domain.BookStock;
 import shop.sajotuna.order.stock.domain.Stock;
 import shop.sajotuna.order.stock.exception.BookStockNotFoundException;
+import shop.sajotuna.order.stock.exception.InsufficientStockException;
 import shop.sajotuna.order.stock.exception.StockProcessingFailedException;
 import shop.sajotuna.order.stock.repository.BookStockRepository;
 
 import java.util.List;
 import java.util.Optional;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class StockServiceTest {
@@ -32,193 +37,174 @@ class StockServiceTest {
     private StockService stockService;
 
     @Test
-    @DisplayName("재고 감소 성공")
+    @DisplayName("decrease stock succeeds with atomic update")
     void decreaseStock_success() {
-        // given
         String isbn = "9781234567890";
         int quantity = 5;
-        BookStock bookStock = createBookStock(isbn, 10);
-        
-        when(bookStockRepository.findByIsbn(isbn)).thenReturn(Optional.of(bookStock));
 
-        // when
+        when(bookStockRepository.decreaseStockAtomically(isbn, quantity)).thenReturn(1);
+
         stockService.decreaseStock(isbn, quantity);
 
-        // then
-        verify(bookStockRepository).findByIsbn(isbn);
+        verify(bookStockRepository).decreaseStockAtomically(isbn, quantity);
+        verify(bookStockRepository, never()).existsByIsbn(isbn);
     }
 
     @Test
-    @DisplayName("재고 감소 실패 - 책을 찾을 수 없음")
+    @DisplayName("decrease stock fails when stock row does not exist")
     void decreaseStock_bookNotFound() {
-        // given
         String isbn = "9781234567890";
         int quantity = 5;
-        
-        when(bookStockRepository.findByIsbn(isbn)).thenReturn(Optional.empty());
 
-        // when & then
+        when(bookStockRepository.decreaseStockAtomically(isbn, quantity)).thenReturn(0);
+        when(bookStockRepository.existsByIsbn(isbn)).thenReturn(false);
+
         assertThatThrownBy(() -> stockService.decreaseStock(isbn, quantity))
                 .isInstanceOf(BookStockNotFoundException.class);
-                
-        verify(bookStockRepository).findByIsbn(isbn);
+
+        verify(bookStockRepository).decreaseStockAtomically(isbn, quantity);
+        verify(bookStockRepository).existsByIsbn(isbn);
     }
 
     @Test
-    @DisplayName("재고 증가 성공")
+    @DisplayName("decrease stock fails when quantity is insufficient")
+    void decreaseStock_insufficientStock() {
+        String isbn = "9781234567890";
+        int quantity = 5;
+
+        when(bookStockRepository.decreaseStockAtomically(isbn, quantity)).thenReturn(0);
+        when(bookStockRepository.existsByIsbn(isbn)).thenReturn(true);
+
+        assertThatThrownBy(() -> stockService.decreaseStock(isbn, quantity))
+                .isInstanceOf(InsufficientStockException.class);
+
+        verify(bookStockRepository).decreaseStockAtomically(isbn, quantity);
+        verify(bookStockRepository).existsByIsbn(isbn);
+    }
+
+    @Test
+    @DisplayName("increase stock succeeds")
     void increaseStock_success() {
-        // given
         String isbn = "9781234567890";
         int quantity = 5;
         BookStock bookStock = createBookStock(isbn, 10);
-        
+
         when(bookStockRepository.findByIsbn(isbn)).thenReturn(Optional.of(bookStock));
 
-        // when
         stockService.increaseStock(isbn, quantity);
 
-        // then
         verify(bookStockRepository).findByIsbn(isbn);
     }
 
     @Test
-    @DisplayName("재고 증가 실패 - 책을 찾을 수 없음")
+    @DisplayName("increase stock fails when stock row does not exist")
     void increaseStock_bookNotFound() {
-        // given
         String isbn = "9781234567890";
         int quantity = 5;
-        
+
         when(bookStockRepository.findByIsbn(isbn)).thenReturn(Optional.empty());
 
-        // when & then
         assertThatThrownBy(() -> stockService.increaseStock(isbn, quantity))
                 .isInstanceOf(BookStockNotFoundException.class);
-                
+
         verify(bookStockRepository).findByIsbn(isbn);
     }
 
     @Test
-    @DisplayName("재고 생성 성공")
+    @DisplayName("create stock succeeds")
     void createStock_success() {
-        // given
         String isbn = "9781234567890";
         int quantity = 10;
         BookStock savedBookStock = createBookStock(isbn, quantity);
-        
+
         when(bookStockRepository.existsByIsbn(isbn)).thenReturn(false);
         when(bookStockRepository.save(any(BookStock.class))).thenReturn(savedBookStock);
 
-        // when
         BookStockResponse result = stockService.createStock(isbn, quantity);
 
-        // then
         assertThat(result).isNotNull();
         assertThat(result.getIsbn()).isEqualTo(isbn);
         assertThat(result.getStockQuantity()).isEqualTo(quantity);
-        
+
         verify(bookStockRepository).existsByIsbn(isbn);
         verify(bookStockRepository).save(any(BookStock.class));
     }
 
     @Test
-    @DisplayName("재고 생성 실패 - 중복된 ISBN")
+    @DisplayName("create stock fails with duplicate ISBN")
     void createStock_duplicateIsbn() {
-        // given
         String isbn = "9781234567890";
         int quantity = 10;
-        
+
         when(bookStockRepository.existsByIsbn(isbn)).thenReturn(true);
 
-        // when & then
         assertThatThrownBy(() -> stockService.createStock(isbn, quantity))
                 .isInstanceOf(DuplicateBookStockException.class);
-                
+
         verify(bookStockRepository).existsByIsbn(isbn);
         verify(bookStockRepository, never()).save(any(BookStock.class));
     }
 
     @Test
-    @DisplayName("여러 재고 생성 성공")
+    @DisplayName("create multiple stocks succeeds")
     void createStocks_success() {
-        // given
         CreateStockRequest request1 = createStockRequest("9781234567890", 10);
         CreateStockRequest request2 = createStockRequest("9781234567891", 5);
         List<CreateStockRequest> requests = List.of(request1, request2);
-        
+
         List<String> isbns = List.of("9781234567890", "9781234567891");
         when(bookStockRepository.findByIsbnIn(isbns)).thenReturn(List.of());
-        
+
         BookStock savedStock1 = createBookStock("9781234567890", 10);
         BookStock savedStock2 = createBookStock("9781234567891", 5);
         when(bookStockRepository.saveAll(any())).thenReturn(List.of(savedStock1, savedStock2));
 
-        // when
         List<BookStockResponse> result = stockService.createStocks(requests);
 
-        // then
         assertThat(result).hasSize(2);
         assertThat(result.get(0).getIsbn()).isEqualTo("9781234567890");
         assertThat(result.get(1).getIsbn()).isEqualTo("9781234567891");
-        
+
         verify(bookStockRepository).findByIsbnIn(isbns);
         verify(bookStockRepository).saveAll(any());
     }
 
     @Test
-    @DisplayName("재고 업데이트 성공")
+    @DisplayName("update stock succeeds")
     void updateStock_success() {
-        // given
         String isbn = "9781234567890";
         int quantity = 15;
         BookStock bookStock = createBookStock(isbn, 10);
-        
+
         when(bookStockRepository.findByIsbn(isbn)).thenReturn(Optional.of(bookStock));
 
-        // when
         stockService.updateStock(isbn, quantity);
 
-        // then
         verify(bookStockRepository).findByIsbn(isbn);
     }
 
     @Test
-    @DisplayName("재고 업데이트 실패 - 책을 찾을 수 없음")
+    @DisplayName("update stock fails when stock row does not exist")
     void updateStock_bookNotFound() {
-        // given
         String isbn = "9781234567890";
         int quantity = 15;
-        
+
         when(bookStockRepository.findByIsbn(isbn)).thenReturn(Optional.empty());
 
-        // when & then
         assertThatThrownBy(() -> stockService.updateStock(isbn, quantity))
                 .isInstanceOf(BookStockNotFoundException.class);
-                
+
         verify(bookStockRepository).findByIsbn(isbn);
     }
 
     @Test
-    @DisplayName("재고 감소 복구 메서드 - OptimisticLockingFailureException 발생")
-    void recoverDecreaseStock_optimisticLockingFailure() {
-        // given
-        String isbn = "9781234567890";
-        int quantity = 5;
-        ObjectOptimisticLockingFailureException exception = new ObjectOptimisticLockingFailureException("test", new RuntimeException());
-
-        // when & then
-        assertThatThrownBy(() -> stockService.recoverDecreaseStock(exception, isbn, quantity))
-                .isInstanceOf(StockProcessingFailedException.class);
-    }
-
-    @Test
-    @DisplayName("재고 증가 복구 메서드 - OptimisticLockingFailureException 발생")
+    @DisplayName("recover increase stock throws stock processing failed exception")
     void recoverIncreaseStock_optimisticLockingFailure() {
-        // given
         String isbn = "9781234567890";
         int quantity = 5;
-        ObjectOptimisticLockingFailureException exception = new ObjectOptimisticLockingFailureException("test", new RuntimeException());
+        ObjectOptimisticLockingFailureException exception =
+                new ObjectOptimisticLockingFailureException("test", new RuntimeException());
 
-        // when & then
         assertThatThrownBy(() -> stockService.recoverIncreaseStock(exception, isbn, quantity))
                 .isInstanceOf(StockProcessingFailedException.class);
     }


### PR DESCRIPTION
## 개요

주문 처리 과정에서 발생할 수 있는 재고 동시성 문제와 회원 등급 산정 방식을 개선했습니다.

기존 재고 차감은 낙관적 락 기반 재시도 방식이라 특정 도서에 주문이 집중될 때 충돌과 retry 비용이 커질 수 있었습니다. 이를 재고 차감 조건을 DB 업데이트 조건에 포함하는 조건부 Atomic Update 방식으로 변경했습니다.

또한 회원 등급 조회 시마다 최근 주문 금액을 재계산하던 흐름을 분리했습니다. 결제 완료, 주문 취소, 반품처럼 등급에 영향을 주는 이벤트가 발생했을 때 등급을 갱신하고, 최근 3개월 기준에서 빠지는 주문은 일일 배치로 보정하도록 롤링 윈도우 구조를 적용했습니다.

## 변경 내용

### 1. 재고 차감 로직 개선

- `BookStockRepository`에 조건부 Atomic Update 쿼리 추가
  - `stock.quantity >= quantity` 조건을 만족할 때만 재고 차감
  - 업데이트 성공 row 수로 재고 차감 성공 여부 판단
  - 재고 변경 시 version 증가 처리
- `StockService.decreaseStock` 로직 변경
  - 재고 차감 시 낙관적 락 retry 제거
  - 차감 수량이 0 이하인 경우 예외 처리
  - 대상 ISBN이 없으면 `BookStockNotFoundException` 발생
  - 재고가 부족하면 `InsufficientStockException` 발생
- 주문 처리 중 일부 상품 재고 차감 후 이후 상품에서 재고 부족이 발생할 때 rollback 되는지 검증하는 테스트 추가
- 기존 재고 서비스 테스트와 동시성 테스트를 변경된 재고 차감 방식에 맞게 수정

### 2. 회원 등급 갱신 방식 개선

- 회원 등급 조회 API에서 등급 재계산 로직 분리
  - 조회 시에는 저장된 회원 등급을 반환하도록 변경
  - 등급 갱신 책임은 별도 `updateGrade` 로직으로 분리
- 결제 완료, 주문 취소, 반품 등 회원 등급에 영향을 주는 주문 상태 변경 시 `UserGradeRefreshEvent` 발행
- `@TransactionalEventListener(phase = AFTER_COMMIT)` 기반으로 주문/결제 트랜잭션 커밋 이후 회원 등급 갱신
- 최근 3개월 산정 기간에서 제외되는 주문을 반영하기 위해 `UserGradeRollingWindowBatchService` 추가
  - 매일 03시에 만료 구간의 주문 보유 사용자를 조회
  - 대상 사용자 등급을 재계산
  - 사용자별 갱신 실패가 전체 배치를 중단시키지 않도록 개별 예외 처리
- 최근 주문 금액 합산과 롤링 윈도우 대상 사용자 조회를 위한 `OrderRepository` 쿼리 추가
- 등급 산정 조회 성능을 고려해 `orders` 테이블에 복합 인덱스 추가
  - `created_at, user_id, status`
  - `user_id, created_at, status`

### 3. 관련 성능 개선

- 주문 조회 시 주문 상품 fetch join 쿼리 보완
- 주문 번호 기반 상세 조회 시 주문 상품 함께 조회
- 사용 가능 쿠폰 조회 과정의 중복 조회 감소
- 주문 금액 계산 시 필요한 데이터를 한 번에 조회하도록 개선

## 변경 이유

### 재고 차감

인기 도서처럼 특정 재고에 주문이 집중되는 상황에서는 낙관적 락 충돌과 retry가 응답 지연으로 이어질 수 있습니다. 재고 차감은 조건 확인과 수량 변경이 함께 처리되어야 하므로 DB 업데이트 조건에 재고 충분 여부를 포함해 원자적으로 처리하는 방식이 더 적합하다고 판단했습니다.

### 회원 등급

회원 등급은 최근 3개월 주문 금액을 기준으로 산정됩니다. 기존처럼 조회 시마다 등급을 갱신하면 단순 조회 요청에서도 주문 금액 계산이 반복될 수 있고, 조회 시점에 따라 갱신 책임이 불명확해질 수 있습니다.

이번 변경에서는 등급에 영향을 주는 주문 이벤트가 발생했을 때 등급을 갱신하고, 시간이 지나 3개월 산정 기간에서 제외되는 주문은 일일 배치로 보정하도록 분리했습니다. 이를 통해 조회와 갱신 책임을 나누고 최근 3개월 기준도 유지할 수 있도록 했습니다.

## 참고

PR 대상 브랜치: `nhnacademy-be10-sajotuna/order-api:dev`

PR 소스 브랜치: `sanikani/bookpang-order-api:dev`